### PR TITLE
ENH: Convert to autopep8 compliant

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,9 +26,9 @@ sys.path.insert(1, sourcepath)
 # -- General configuration ---------------------------------------------------
 
 # Try to override the matplotlib configuration as early as possible
-#try:
+# try:
 #    import gen_rst
-#except:
+# except:
 #    pass
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -132,7 +132,7 @@ html_theme = 'sphinxdoc'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {'oldversion': False, 'collapsiblesidebar': True,
+# html_theme_options = {'oldversion': False, 'collapsiblesidebar': True,
 #                      'google_analytics': True
 #                      }
 

--- a/tract_querier/aabb.py
+++ b/tract_querier/aabb.py
@@ -4,6 +4,7 @@ __all__ = ['BoundingBox']
 
 
 class BoundingBox(np.ndarray):
+
     """Bounding box assuming RAS coordinate system"""
     def __new__(cls, input_array, info=None):
         try:
@@ -201,7 +202,7 @@ class AABBTree:
             if isinstance(tree, self.leaf):
                 return [tree]
             else:
-                return self._intersect(tree.left, box)+self._intersect(tree.right, box)
+                return self._intersect(tree.left, box) + self._intersect(tree.right, box)
         else:
             return []
 
@@ -213,7 +214,6 @@ class AABBTree:
             if len(indices) == 1:
                 return self.leaf(allboxes[indices[0], :], indices[0], parent=parent)
             boxes = allboxes[indices, :]
-
 
     def buildTree_old(self, allboxes, indices=None, leafPointers=None, parent=None, verbose=False):
         """
@@ -232,7 +232,7 @@ class AABBTree:
         if verbose:
             print '*******************************************'
 
-        dimensions = len(boxes[0])/2
+        dimensions = len(boxes[0]) / 2
 
         box = np.empty(2 * dimensions)
         np.min(boxes[:, ::2], axis=0, out=box[::2])
@@ -240,16 +240,16 @@ class AABBTree:
         boxes[:, ::2].min(0, out=box[::2])
         boxes[:, 1::2].max(0, out=box[1::2])
 
-        lengths = box[1::2]-box[::2]
+        lengths = box[1::2] - box[::2]
         largestDimension = lengths.argmax()
         largestDimensionLength = lengths[largestDimension]
-        cuttingPlaneAt = largestDimensionLength/2.
+        cuttingPlaneAt = largestDimensionLength / 2.
 
         halfLength = (
-            boxes[:, 2*largestDimension] +
+            boxes[:, 2 * largestDimension] +
             (
-                boxes[:, 2*largestDimension+1]-boxes[:, 2*largestDimension]
-            )/2.
+                boxes[:, 2 * largestDimension + 1] - boxes[:, 2 * largestDimension]
+            ) / 2.
         )
 
         halfLengthSortedIndices = halfLength.argsort()
@@ -260,7 +260,7 @@ class AABBTree:
         rightIndices = indices[halfLengthSortedIndices[division:]]
 
         if len(leftIndices) == 0 or len(rightIndices) == 0:
-            n = len(indices)/2
+            n = len(indices) / 2
             leftIndices = indices[:n]
             rightIndices = indices[n:]
 

--- a/tract_querier/code_util/__init__.py
+++ b/tract_querier/code_util/__init__.py
@@ -1,4 +1,5 @@
 class DocStringInheritor(type):
+
     '''A variation on
     http://groups.google.com/group/comp.lang.python/msg/26f7b4fcb4d66c95
     by Paul McGuire
@@ -25,8 +26,10 @@ import sys
 
 
 class Test(unittest.TestCase):
+
     def test_null(self):
         class Foo(object):
+
             def frobnicate(self):
                 pass
 
@@ -38,7 +41,9 @@ class Test(unittest.TestCase):
 
     def test_inherit_from_parent(self):
         class Foo(object):
+
             'Foo'
+
             def frobnicate(self):
                 'Frobnicate this gonk.'
         class Bar(Foo):
@@ -51,7 +56,9 @@ class Test(unittest.TestCase):
 
     def test_inherit_from_mro(self):
         class Foo(object):
+
             'Foo'
+
             def frobnicate(self):
                 'Frobnicate this gonk.'
         class Bar(Foo):
@@ -65,7 +72,9 @@ class Test(unittest.TestCase):
 
     def test_inherit_metaclass_(self):
         class Foo(object):
+
             'Foo'
+
             def frobnicate(self):
                 'Frobnicate this gonk.'
         class Bar(Foo):

--- a/tract_querier/nipype/setup.py
+++ b/tract_querier/nipype/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('nipype', parent_package, top_path)

--- a/tract_querier/nipype/utils.py
+++ b/tract_querier/nipype/utils.py
@@ -9,26 +9,28 @@ from itertools import izip
 from nipype.interfaces.base import (TraitedSpec, traits)
 from nipype.interfaces.ants import utils
 
+
 class ANTSAffineCommandInputSpec(utils.ANTSCommandInputSpec):
     dimension = traits.Enum(3, 2, argstr='%d', usedefault=True,
-                             desc='image dimension (2 or 3)', position=1)
+                            desc='image dimension (2 or 3)', position=1)
 
     reference_image = traits.File(
-                           argstr='%s', desc='template file to warp to',
-                           mandatory=True, copyfile=True, position=2)
+        argstr='%s', desc='template file to warp to',
+        mandatory=True, copyfile=True, position=2)
 
     input_image = traits.File(
-                       argstr='%s', desc='input image to warp to template',
-                       mandatory=True, copyfile=False, position=3)
+        argstr='%s', desc='input image to warp to template',
+        mandatory=True, copyfile=False, position=3)
 
     out_prefix = traits.Str('ants_', argstr='%s', usedefault=True,
-                             desc=('Prefix that is prepended to all output '
-                                   'files (default = ants_)'), position=4)
+                            desc=('Prefix that is prepended to all output '
+                                  'files (default = ants_)'), position=4)
 
     rigid_affine = traits.Bool(False,
-                        argstr='1',
-                        usedefault=False, position=5
-                    )
+                               argstr='1',
+                               usedefault=False, position=5
+                               )
+
 
 class ANTSAffineCommandOutputSpec(TraitedSpec):
     affine_transformation = traits.File(
@@ -37,10 +39,12 @@ class ANTSAffineCommandOutputSpec(TraitedSpec):
     )
 
     deformed_image = traits.File(
-                            exists=True,
-                            desc='deformed_image')
+        exists=True,
+        desc='deformed_image')
+
 
 class GenAffine(utils.ANTSCommand):
+
     """Uses ANTS to generate matrices to warp data from one space to another.
 
     Examples
@@ -61,78 +65,77 @@ class GenAffine(utils.ANTSCommand):
         outputs = self._outputs().get()
 
         outputs['affine_transformation'] = os.path.join(os.getcwd(),
-                            self.inputs.out_prefix + 'Affine.txt')
+                                                        self.inputs.out_prefix + 'Affine.txt')
 
         outputs['deformed_image'] = os.path.join(os.getcwd(),
-                            self.inputs.out_prefix + 'deformed.nii.gz')
-
+                                                 self.inputs.out_prefix + 'deformed.nii.gz')
 
         return outputs
 
 
 class ANTSCommandInputSpec(utils.ANTSCommandInputSpec):
     dimension = traits.Enum(3, 2, argstr='%d', usedefault=True,
-                             desc='image dimension (2 or 3)', position=1)
+                            desc='image dimension (2 or 3)', position=1)
     reference_images = traits.List(traits.File, sep=',',
-                           argstr='', desc='template file to warp to',
-                           mandatory=True, copyfile=True, position=2)
+                                   argstr='', desc='template file to warp to',
+                                   mandatory=True, copyfile=True, position=2)
     input_images = traits.List(traits.File, sep=',',
-                       argstr='', desc='input image to warp to template',
-                       mandatory=True, copyfile=False, position=3)
+                               argstr='', desc='input image to warp to template',
+                               mandatory=True, copyfile=False, position=3)
     metric_weights = traits.List(traits.Float, [1], argstr='',
-                            desc='Different weights for metric combinations',
-                            usedefault=True
-                        )
+                                 desc='Different weights for metric combinations',
+                                 usedefault=True
+                                 )
     max_iterations = traits.List(traits.Int, [30, 90, 20], argstr='-i %s',
-                             sep='x', usedefault=True,
-                             desc=('maximum number of iterations (must be '
-                                   'list of integers in the form [J,K,L...]: '
-                                   'J = coarsest resolution iterations, K = '
-                                   'middle resolution interations, L = fine '
-                                   'resolution iterations'), position=4)
+                                 sep='x', usedefault=True,
+                                 desc=('maximum number of iterations (must be '
+                                       'list of integers in the form [J,K,L...]: '
+                                       'J = coarsest resolution iterations, K = '
+                                       'middle resolution interations, L = fine '
+                                       'resolution iterations'), position=4)
     regularization_parameters = traits.List(traits.Float, [3., 0.],
-                                 argstr='-r Gauss[%s]', sep=',', usedefault=True,
-                                desc=('Parameters for the regularization'),
-                                position=5)
+                                            argstr='-r Gauss[%s]', sep=',', usedefault=True,
+                                            desc=('Parameters for the regularization'),
+                                            position=5)
     transformation_parameters = traits.List(traits.Float, [.25, 2, 0.05], argstr='-t SyN[%s]',
-                            sep=',', usedefault=True,
-                            desc=('Parameters for the transformation'),
-                            position=6)
+                                            sep=',', usedefault=True,
+                                            desc=('Parameters for the transformation'),
+                                            position=6)
     out_prefix = traits.Str('ants_', argstr='-o %s', usedefault=True,
-                             desc=('Prefix that is prepended to all output '
-                                   'files (default = ants_)'), position=7)
+                            desc=('Prefix that is prepended to all output '
+                                  'files (default = ants_)'), position=7)
 
     use_histogram_matching = traits.Bool(True,
-                                        argstr='--use-Histogram-Matching',
-                                        usedefault=True, position=8)
+                                         argstr='--use-Histogram-Matching',
+                                         usedefault=True, position=8)
 
     number_of_affine_iterations = traits.List(traits.Int, [10000, ] * 5,
-                            argstr='--number-of-affine-iterations %s', sep='x',
-                            usedefault=True, position=9)
+                                              argstr='--number-of-affine-iterations %s', sep='x',
+                                              usedefault=True, position=9)
 
     mi_option = traits.List(traits.Int, [32, 16000],
                             argstr='--MI-option %s', sep='x',
                             usedefault=True, position=10)
 
     affine_metric = traits.Enum('MI', 'CC', 'MSQ', 'PR', argstr='--affine-metric-type %s',
-            desc=('Type of similartiy metric used for affine registration '
-                  '(CC = cross correlation, MI = mutual information, '
-                  'PR = probability mapping, MSQ = mean square difference)'),
-            usedefault=True, position=11)
+                                desc=('Type of similartiy metric used for affine registration '
+                                      '(CC = cross correlation, MI = mutual information, '
+                                      'PR = probability mapping, MSQ = mean square difference)'),
+                                usedefault=True, position=11)
 
     initial_affine = traits.File(exists=False,
-                    argstr='-a %s', desc='Initial affine transform',
-                    mandatory=False, copyfile=False, position=12)
+                                 argstr='-a %s', desc='Initial affine transform',
+                                 mandatory=False, copyfile=False, position=12)
 
     rigid_affine = traits.Bool(False,
-                        argstr='--rigid-affine true',
-                        usedefault=False, position=13
-                    )
+                               argstr='--rigid-affine true',
+                               usedefault=False, position=13
+                               )
 
     not_continue_affine = traits.Bool(False,
-                        argstr='--continue-affine false',
-                        usedefault=False, position=14
-                    )
+                                      argstr='--continue-affine false',
+                                      usedefault=False, position=14
+                                      )
 
 
 class ANTSCommandOutputSpec(TraitedSpec):
@@ -145,16 +148,18 @@ class ANTSCommandOutputSpec(TraitedSpec):
         desc='warp field (prefix_Warp.nii)'
     )
     inverse_warp_field = traits.File(exists=False,
-                            desc='inverse warp field (prefix_InverseWarp.nii)')
+                                     desc='inverse warp field (prefix_InverseWarp.nii)')
     input_file = traits.File(
-                            exists=True,
-                            desc='input image (prefix_repaired.nii)')
+        exists=True,
+        desc='input image (prefix_repaired.nii)')
 
     transforms = traits.List(traits.File, desc='transform list')
 
     inverse_transforms = traits.List(traits.File, desc='transform list with inversed warp (but not affine)')
 
+
 class GenWarpFields(utils.ANTSCommand):
+
     """Uses ANTS to generate matrices to warp data from one space to another.
 
     Examples
@@ -198,7 +203,7 @@ class GenWarpFields(utils.ANTSCommand):
             ):
                 arg_string = ''
                 N = len(self._internal['reference_images'])
-                if  len(self._internal['input_images']) != N:
+                if len(self._internal['input_images']) != N:
                     raise ValueError(
                         'The number of reference and'
                         'input images must be the same'
@@ -231,14 +236,14 @@ class GenWarpFields(utils.ANTSCommand):
         outputs = self._outputs().get()
 
         outputs['affine_transformation'] = os.path.join(os.getcwd(),
-                            self.inputs.out_prefix + 'Affine.txt')
+                                                        self.inputs.out_prefix + 'Affine.txt')
 
         out_warp = os.path.join(os.getcwd(),
-                                             self.inputs.out_prefix +
-                                             'Warp.nii.gz')
+                                self.inputs.out_prefix +
+                                'Warp.nii.gz')
         out_inv_warp = os.path.join(os.getcwd(),
-                                             self.inputs.out_prefix +
-                                             'InverseWarp.nii.gz')
+                                    self.inputs.out_prefix +
+                                    'InverseWarp.nii.gz')
 
         if os.path.exists(out_warp):
             outputs['warp_field'] = out_warp

--- a/tract_querier/nipype/wmql.py
+++ b/tract_querier/nipype/wmql.py
@@ -7,6 +7,7 @@ import glob
 
 from nipype.interfaces.base import (CommandLine, CommandLineInputSpec, TraitedSpec, traits)
 
+
 class TractQuerierInputSpec(CommandLineInputSpec):
     atlas_type = traits.Enum('Desikan', 'Mori', argstr='-q %s', usedefault=True,
                              desc='Atlas type for the queries')
@@ -16,11 +17,12 @@ class TractQuerierInputSpec(CommandLineInputSpec):
     queries = traits.List(desc="Input queries", exists=True, mandatory=False, argstr="--query_selection %s")
 
 
-
 class TractQuerierOutputSpec(TraitedSpec):
     output_queries = traits.List(exists=True, desc='resulting query files')
 
+
 class TractQuerier(CommandLine):
+
     """Uses WMQL to generate white matter tracts
 
     Examples
@@ -43,34 +45,32 @@ class TractQuerier(CommandLine):
     input_spec = TractQuerierInputSpec
     output_spec = TractQuerierOutputSpec
 
-
     def _format_arg(self, name, spec, value):
         if name == 'atlas_type':
-            return spec.argstr%{"Mori":'mori_queries.qry', "Desikan":'freesurfer_queries.qry'}[value]
+            return spec.argstr % {"Mori": 'mori_queries.qry', "Desikan": 'freesurfer_queries.qry'}[value]
         elif name == 'queries':
-            return spec.argstr%(''.join((q + ',' for q in value[:-1])) + value[-1])
+            return spec.argstr % (''.join((q + ',' for q in value[:-1])) + value[-1])
         return super(TractQuerier, self)._format_arg(name, spec, value)
 
     def _list_outputs(self):
         outputs = self._outputs().get()
         outputs['output_queries'] = glob.glob(os.path.join(os.getcwd(),
-                                                        self.inputs.out_prefix +
-                                                        '*.vtk')
-                                             )
+                                                           self.inputs.out_prefix +
+                                                           '*.vtk')
+                                              )
         return outputs
 
 
 class MapImageToTractsInputSpec(CommandLineInputSpec):
-    input_tractography = traits.File(desc = "Input Tractography", exists = False, mandatory = True, argstr="%s", copy_file=False, position=0)
-    input_image = traits.File(desc = "Input Image", exists = False, mandatory = True, argstr="-i %s", copy_file=False)
-    output_tractography_prefix = traits.File('out_', desc = "output tract name", mandatory = False, argstr="-o %s", usedefault=True)
-    data_name = traits.String(desc = "Name of the property", mandatory = True, argstr="-n %s")
+    input_tractography = traits.File(desc="Input Tractography", exists=False, mandatory=True, argstr="%s", copy_file=False, position=0)
+    input_image = traits.File(desc="Input Image", exists=False, mandatory=True, argstr="-i %s", copy_file=False)
+    output_tractography_prefix = traits.File('out_', desc="output tract name", mandatory=False, argstr="-o %s", usedefault=True)
+    data_name = traits.String(desc="Name of the property", mandatory=True, argstr="-n %s")
     output_point_value_prefix = traits.File(
         'out_',
         desc="Values of the image at every point of the tract", exists=False, mandatory=False, argstr="--output_point_value_file %s",
         usedefault=True
     )
-
 
 
 class MapImageToTractsOutputSpec(TraitedSpec):
@@ -79,6 +79,7 @@ class MapImageToTractsOutputSpec(TraitedSpec):
 
 
 class MapImageToTracts(CommandLine):
+
     """Uses WMQL to generate white matter tracts
 
     Examples
@@ -101,17 +102,17 @@ class MapImageToTracts(CommandLine):
 
     def _format_arg(self, name, spec, value):
         if name == 'output_tractography_prefix':
-            return spec.argstr%((
+            return spec.argstr % ((
                 value + os.path.basename(self.inputs.input_tractography)
             ))
 
         if name == 'output_point_value_prefix':
             basename = os.path.basename(self.inputs.input_tractography)
             name, ext = os.path.splitext(basename)
-            return spec.argstr%((
-                    value +
-                    name +
-                    '.txt'
+            return spec.argstr % ((
+                value +
+                name +
+                '.txt'
             ))
 
         return super(MapImageToTracts, self)._format_arg(name, spec, value)
@@ -134,6 +135,6 @@ class MapImageToTracts(CommandLine):
                 self.inputs.output_point_value_prefix +
                 name +
                 '.txt'
-        ))
+            ))
 
         return outputs

--- a/tract_querier/query_processor.py
+++ b/tract_querier/query_processor.py
@@ -26,6 +26,7 @@ keywords = [
 
 
 class FiberQueryInfo(object):
+
     r"""
     Information about a processed query
 
@@ -38,6 +39,7 @@ class FiberQueryInfo(object):
         tracts_endpoints : (set, set)
             sets of labels of where the tract endpoints are
     """
+
     def __init__(self, tracts=None, labels=None, tracts_endpoints=None):
         if tracts is None:
             tracts = set()
@@ -62,7 +64,7 @@ class FiberQueryInfo(object):
         return FiberQueryInfo(
             self.tracts.copy(), self.labels.copy(),
             (self.tracts_endpoints[0].copy(), self.tracts_endpoints[1].copy()),
-#            (self.labels_endpoints[0].copy(), self.labels_endpoints[1].copy()),
+            #            (self.labels_endpoints[0].copy(), self.labels_endpoints[1].copy()),
         )
 
     def set_operation(self, name):
@@ -101,6 +103,7 @@ class FiberQueryInfo(object):
 
 
 class EndpointQueryInfo:
+
     def __init__(
         self,
         endpoint_tracts=None,
@@ -165,6 +168,7 @@ class EndpointQueryInfo:
 
 
 class EvaluateQueries(ast.NodeVisitor):
+
     r"""
     This class implements the parser to process
     White Matter Query Language modules. By inheriting from
@@ -324,14 +328,14 @@ class EvaluateQueries(ast.NodeVisitor):
                 query_info = self.visit(node.args[0])
                 new_tracts = query_info.tracts_endpoints[0].union(query_info.tracts_endpoints[1])
 
-                #tracts = set().union(set(
+                # tracts = set().union(set(
                 #    tract for tract in query_info.tracts
                 #    if (
                 #        self.tractography_spatial_indexing.ending_tracts_labels[i][tract] in query_info.labels
                 #    )
                 #))
 
-                #labels = set().union(
+                # labels = set().union(
                 #    *tuple((self.tractography_spatial_indexing.crossing_tracts_labels[tract] for tract in tracts))
                 #)
                 return FiberQueryInfo(new_tracts, query_info.labels, query_info.tracts_endpoints)
@@ -642,6 +646,7 @@ class EvaluateQueries(ast.NodeVisitor):
 
 
 class TractQuerierSyntaxError(ValueError):
+
     def __init__(self, value):
         self.value = value
 
@@ -650,6 +655,7 @@ class TractQuerierSyntaxError(ValueError):
 
 
 class RewriteChangeNotInPrescedence(ast.NodeTransformer):
+
     def visit_BoolOp(self, node):
         predicate = lambda value: not (
             isinstance(value, ast.Compare) and
@@ -704,6 +710,7 @@ class RewriteChangeNotInPrescedence(ast.NodeTransformer):
 
 
 class RewritePreprocess(ast.NodeTransformer):
+
     def __init__(self, *args, **kwargs):
         if 'include_folders' in kwargs:
             self.include_folders = kwargs['include_folders']
@@ -822,6 +829,7 @@ def eval_queries(
 
 def queries_syntax_check(query_file_body):
     class DummySpatialIndexing:
+
         def __init__(self):
             self.crossing_tracts_labels = {}
             self.crossing_labels_tracts = {}

--- a/tract_querier/shell.py
+++ b/tract_querier/shell.py
@@ -21,6 +21,7 @@ def safe_method(f):
 
 
 class SaveQueries(ast.NodeVisitor):
+
     def __init__(self, save_query_callback, querier):
         self.save_query_callback = save_query_callback
         self.querier = querier
@@ -85,11 +86,12 @@ class SaveQueries(ast.NodeVisitor):
             self.visit(line)
 
     def visit_For(self, node):
-        #If it is a for loop, only execute
+        # If it is a for loop, only execute
         pass
 
 
 class TractQuerierCmd(cmd.Cmd):
+
     def __init__(
             self,
             tractography_spatial_indexing,

--- a/tract_querier/tests/tests_query_eval.py
+++ b/tract_querier/tests/tests_query_eval.py
@@ -4,7 +4,7 @@ from nose.tools import assert_true, assert_equal
 from numpy import random
 import ast
 
-#Ten tracts traversing random labels
+# Ten tracts traversing random labels
 another_set = True
 while (another_set):
     tracts_labels = dict([(i, set(random.randint(100, size=2))) for i in xrange(100)])
@@ -18,6 +18,7 @@ tract_in_label_0_uniquely = labels_tracts[0].difference(tracts_in_all_but_0)
 
 
 class DummySpatialIndexing:
+
     def __init__(
         self,
         crossing_tracts_labels, crossing_labels_tracts,

--- a/tract_querier/tests/tests_query_rewrite.py
+++ b/tract_querier/tests/tests_query_rewrite.py
@@ -10,6 +10,7 @@ import token
 import symbol
 from types import ListType, TupleType
 
+
 def match(pattern, data, vars=None):
     if vars is None:
         vars = {}
@@ -25,6 +26,7 @@ def match(pattern, data, vars=None):
         if not same:
             break
     return same, vars
+
 
 @expectedFailure
 def test_rewrite_notin_precedence():

--- a/tract_querier/tract_label_indices.py
+++ b/tract_querier/tract_label_indices.py
@@ -7,6 +7,7 @@ __all__ = ['TractographySpatialIndexing']
 
 
 class TractographySpatialIndexing:
+
     r"""
     This class implements a mutual spatial indexing of
     an labeled image and a tractography

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -1,9 +1,9 @@
 from .decorator import tract_math_operation
 
 try:
-	from collections import OrderedDict
+    from collections import OrderedDict
 except ImportError:  # Python 2.6 fix
-	from ordereddict import OrderedDict
+    from ordereddict import OrderedDict
 
 import numpy
 
@@ -17,8 +17,8 @@ from ..tractography import Tractography, tractography_to_file, tractography_from
 def count(tractographies):
     results = {'tract file #': [], 'number of tracts': []}
     for i, tractography in enumerate(tractographies):
-	    results['tract file #'].append(i)
-	    results['number of tracts'].append(len(tractography.tracts()))
+        results['tract file #'].append(i)
+        results['number of tracts'].append(len(tractography.tracts()))
     return results
 
 
@@ -270,8 +270,8 @@ def tract_generate_probability_map(tractographies, image, file_output):
     prob_map = tract_probability_map(image, tractographies[0]).astype(float)
 
     for tract in tractographies[1:]:
-	if len(tract.tracts()) == 0:
-		continue
+        if len(tract.tracts()) == 0:
+            continue
         new_prob_map = tract_mask(image, tract)
         prob_map = prob_map + new_prob_map - (prob_map * new_prob_map)
 

--- a/tract_querier/tractography/setup.py
+++ b/tract_querier/tractography/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('tractography', parent_package, top_path)

--- a/tract_querier/tractography/tests/test_tractography.py
+++ b/tract_querier/tractography/tests/test_tractography.py
@@ -77,7 +77,7 @@ def setup(*args, **kwargs):
 
     if test_active_data:
         mask = 0
-        for  k, v in tracts_data.items():
+        for k, v in tracts_data.items():
             if mask & (1 + 2 + 4):
                 break
             if v[0].shape[1] == 1 and mask & 1 == 0:
@@ -89,7 +89,6 @@ def setup(*args, **kwargs):
             if v[0].shape[1] == 9 and mask & 4 == 0:
                 tracts_data['ActiveTensors'] = k
                 mask |= 4
-
 
     tractography = Tractography(tracts, tracts_data)
 

--- a/tract_querier/tractography/trackvis.py
+++ b/tract_querier/tractography/trackvis.py
@@ -38,10 +38,8 @@ def tractography_to_trackvis_file(filename, tractography, affine=None, image_dim
         else:
             data[k] = v
 
-
-
     #data_new = {}
-    #for k, v in data.iteritems():
+    # for k, v in data.iteritems():
     #    if (v[0].ndim > 1 and v[0].shape[1] > 1):
     #        for i in xrange(v[0].shape[1]):
     #            data_new['%s_%02d' % (k, i)] = [
@@ -49,7 +47,6 @@ def tractography_to_trackvis_file(filename, tractography, affine=None, image_dim
     #            ]
     #    else:
     #       data_new[k] = v
-
     trk_header['n_count'] = len(tractography.tracts())
     trk_header['n_properties'] = 0
     trk_header['n_scalars'] = len(data)
@@ -84,7 +81,7 @@ def tractography_from_trackvis_file(filename):
 
     #scalar_names_unique = []
     #scalar_names_subcomp = {}
-    #for sn in scalar_names:
+    # for sn in scalar_names:
     #    if re.match('.*_[0-9]{2}', sn):
     #        prefix = sn[:sn.rfind('_')]
     #        if prefix not in scalar_names_unique:

--- a/tract_querier/tractography/tractography.py
+++ b/tract_querier/tractography/tractography.py
@@ -4,6 +4,7 @@ __all__ = ['Tractography']
 
 
 class Tractography:
+
     r"""
     Class to represent a tractography dataset
 

--- a/tract_querier/tractography/vtkInterface.py
+++ b/tract_querier/tractography/vtkInterface.py
@@ -110,6 +110,7 @@ def vtkPolyData_to_tracts(polydata, return_tractography_object=True):
     else:
         return tracts, data
 
+
 def vtkPolyData_dictionary_to_tracts_and_data(dictionary):
     r'''
     Create a tractography from a dictionary

--- a/tract_querier/util.py
+++ b/tract_querier/util.py
@@ -1,11 +1,12 @@
 class LabelsBundles:
+
     def __init__(self):
         self.key_tracts_value_labels = {}
         self.key_labels_value_tracts = {}
 
     def append_tract(self, tract, labels):
         if tract not in self.key_tracts_value_labels:
-            self.key_tracts_value_labels[tract]= set(labels)
+            self.key_tracts_value_labels[tract] = set(labels)
         else:
             self.key_tracts_value_labels[tract].update(labels)
 
@@ -14,13 +15,12 @@ class LabelsBundles:
 
     def append_label(self, label, tracts):
         if label not in self.key_labels_value_tracts:
-            self.key_labels_value_tracts[label]= set(tracts)
+            self.key_labels_value_tracts[label] = set(tracts)
         else:
             self.key_labels_value_tracts[label].update(tracts)
 
         for tract in tracts:
             self.key_tracts_value_labels[tract].append(label)
-
 
     def get_tract(self, tract):
         return self.key_tracts_value_labels[tract]


### PR DESCRIPTION
Used mechanism to make the code consistent with pep8 standards
to be compliant with nipype and other standards.

This was prompted by warnings given for inconsistent indentation
warnings by the editor.  There were many places where tab indentation
was followed by space indentation.

This change also makes the code easier to read for those of us
are used to nipype and strict pep8 compliant.
