### PR TITLE
Improve the way the default queries search path is searched

### DIFF
--- a/tract_querier/__init__.py
+++ b/tract_querier/__init__.py
@@ -8,21 +8,27 @@ import tractography
 
 
 def find_queries_path():
-    default_data_path = sysconfig.get_path(name='data')
-    queries_path = os.path.join(default_data_path, 'tract_querier', 'queries')
+    default_path = sysconfig.get_path(name='data')
+    possible_paths = [os.path.join(default_path, 'tract_querier', 'queries')]
 
-    if not os.path.exists(queries_path):
-        # Try to manage Virtual Environments on some OSes,
-        # where data is not put the 'local' subdirectory,
-        # but at the root of the virtual environment.
-        if default_data_path.endswith('local'):
-            queries_path = os.path.join(default_data_path.rsplit('local', 1)[0],
-                                        'tract_querier', 'queries')
+    # Try to manage Virtual Environments on some OSes,
+    # where data is not put the 'local' subdirectory,
+    # but at the root of the virtual environment.
+    if default_path.endswith('local'):
+        possible_paths.append(os.path.join(default_path.rsplit('local', 1)[0],
+                                           'tract_querier', 'queries'))
 
-            if not os.path.exists(queries_path):
-                raise Exception('Default path for queries not found')
+    # Case where the Tract_querier is cloned from git and simply
+    # added to the python path, without installation.
+    possible_paths.append(os.path.abspath(os.path.join(
+                                          os.path.dirname(__file__), 'data')))
 
-    return queries_path
+    paths_found = [path for path in possible_paths if os.path.exists(path)]
+
+    if not paths_found:
+        raise Exception('Default path for queries not found')
+
+    return paths_found[0]
 
 
 default_queries_folder = find_queries_path()


### PR DESCRIPTION
The default queries search path was assumed to be 4 levels higher in the hierarchy. However, in some specific cases, that may not be the case.

For example, on Ubuntu 12.04, trying to pip install the Tract Querier in a Python Virtual Environment (using virtualenv v. 1.11.6), the path that is found for **file** in **init.py** is one level too deep. In that case, the heuristic of 4 levels higher in the hierarchy doesn't work, resulting in the tract_querier script failing to find FreeSurfer.qry file.

To overcome this, we can use the sysconfig get_path function. The queries are normally in that folder. We also explore one level higher if the path is not found, to overcome the additionnal local/ subdirectory in a venv.

Was tested on OSX with and without a virtual environment on Anaconda, and on Ubuntu 12.04 with and without a Virtual Environment.

A list of the paths found is available in this gist: https://gist.github.com/jchoude/d812330afd1c90a79298
