### PR TITLE
ENH: Added option to improve creating csv files

### DIFF
--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -7,6 +7,7 @@ import traceback
 
 import warnings
 
+
 def custom_formatwarning(msg, *a):
     # ignore everything except the message
     return '\nWarning: ' + str(msg) + '\n'
@@ -42,7 +43,7 @@ def main():
 
     optional flags:  Always start with "--" and are considered as boolean flags
 
-    The --useFileNamesAsIndex col_name1:path_dir_index col_name2:path_dir_index2 .. col_nameN:path_dir_indexN
+    The --use_file_names_as_index col_name1:path_dir_index col_name2:path_dir_index2 .. col_nameN:path_dir_indexN
         Example directory layout:
         =========================
         PROJ_XX/SUBJ_01/SESSION_AB/cm1.left.vtp
@@ -69,7 +70,7 @@ def main():
     for f in operations_names:
         usage += '\t%s %s\n' % (f, operations[f].help_text)
 
-    #The first arguments, except for the last one, might be tractography files
+    # The first arguments, except for the last one, might be tractography files
 
     n_tracts = len([
         tract for tract in
@@ -80,36 +81,41 @@ def main():
     ])
 
     parser = ArgumentParser(usage=usage)
-    parser.add_argument('tractographies', nargs=max(n_tracts, 1), help='tractography files', type=FileType('r'))
+    parser.add_argument('tractographies', nargs=max(
+        n_tracts, 1), help='tractography files', type=FileType('r'))
     parser.add_argument('operation', type=str, choices=operations_names,
                         help="operation to use")
     parser.add_argument('operation_parameters', type=str, nargs=REMAINDER,
                         help="operation parameters")
 
     args = parser.parse_args()
-    #Load the global modules after the parsing of parameters
+    # Load the global modules after the parsing of parameters
     from tract_querier.tractography import tractography_from_files
 
-    if  (args.operation in operations) and operations[args.operation].needs_one_tract:
-        tractography = tractography_from_files([f.name for f in args.tractographies])
+    if (args.operation in operations) and operations[args.operation].needs_one_tract:
+        tractography = tractography_from_files(
+            [f.name for f in args.tractographies])
     else:
         tractography = []
         try:
             for f in args.tractographies:
-                # For each tractography file, pass a tuple of (tractography filename, tractography instance) to tractography list.
-                tractography.append((f.name,tractography_from_files(f.name)))
+                # For each tractography file, pass a tuple of (tractography
+                # filename, tractography instance) to tractography list.
+                tractography.append((f.name, tractography_from_files(f.name)))
         except IOError as e:
             print >>sys.stderr, "Error reading file ", f.name, "(%s)" % repr(e)
 
-    if  args.operation in operations:
+    if args.operation in operations:
         try:
-            operations[args.operation](tractography, *args.operation_parameters)
+            operations[args.operation](
+                tractography, *args.operation_parameters)
         except TractMathWrongArgumentsError, e:
             traceback.print_exc(file=sys.stdout)
             parser.error('\n\n' + str(e))
         except TypeError:
             traceback.print_exc(file=sys.stdout)
-            parser.error("\n\nError: Wrong number of parameters for the operation")
+            parser.error(
+                "\n\nError: Wrong number of parameters for the operation")
 
     else:
         parser.error("\n\nOperation not found")

--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -3,6 +3,8 @@ import sys
 import itertools
 from argparse import ArgumentParser, FileType, REMAINDER
 
+import traceback
+
 import warnings
 
 def custom_formatwarning(msg, *a):
@@ -35,7 +37,29 @@ def main():
     from tract_querier.tract_math import TractMathWrongArgumentsError
 
     usage = r"""
-    usage: %(prog)s <tract1.vtk> ... <tractN.vtk> operation <operation parameter1> ... <operation parameterN> <output_tract.vtk>
+    usage: %(prog)s <tract1.vtk> ... <tractN.vtk> operation <operation parameter1> ... <operation parameterN> <output_tract.vtk> \
+                      [ optional flags ]
+
+    optional flags:  Always start with "--" and are considered as boolean flags
+
+    The --useFileNamesAsIndex col_name1:path_dir_index col_name2:path_dir_index2 .. col_nameN:path_dir_indexN
+        Example directory layout:
+        =========================
+        PROJ_XX/SUBJ_01/SESSION_AB/cm1.left.vtp
+        PROJ_XX/SUBJ_01/SESSION_AB/cm1.right.vtp
+        ||||||| ||||||| |||||||||| ||||||||||||||||||||||||
+        4444444 3333333 2222222222 111111111111111111111111
+
+        tract_math call:
+        ================
+        tract_math PROJ_XX/SUBJ_01/SESSION_AB/*.vtp count test.csv --useFileNamesAsIndex proj:4 subj:3 sess:2 tract:1
+
+        result:
+        =======
+        $ cat test.csv
+        sess,number of tracts,subj,proj,tract
+        SESSION_AB,176,SUBJ_01,PROJ_XX,cm1.left.vtp
+        SESSION_AB,88,SUBJ_01,PROJ_XX,cm1.right.vtp
 
     Available operations:
     """
@@ -72,7 +96,8 @@ def main():
         tractography = []
         try:
             for f in args.tractographies:
-                tractography.append(tractography_from_files(f.name))
+                # For each tractography file, pass a tuple of (tractography filename, tractography instance) to tractography list.
+                tractography.append((f.name,tractography_from_files(f.name)))
         except IOError as e:
             print >>sys.stderr, "Error reading file ", f.name, "(%s)" % repr(e)
 
@@ -80,9 +105,12 @@ def main():
         try:
             operations[args.operation](tractography, *args.operation_parameters)
         except TractMathWrongArgumentsError, e:
+            traceback.print_exc(file=sys.stdout)
             parser.error('\n\n' + str(e))
         except TypeError:
-            parser.error("\n\nWrong number of parameters for the operation")
+            traceback.print_exc(file=sys.stdout)
+            parser.error("\n\nError: Wrong number of parameters for the operation")
+
     else:
         parser.error("\n\nOperation not found")
 

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -25,47 +25,48 @@ def tract_math_operation(help_text, needs_one_tract=True):
     needs_one_tract: tells the script if all the input tractographies should
                       be unified as one or left as a tractography list
     '''
-    def parse_optional_args(optional_args,current_dict):
+    def parse_optional_args(optional_args, current_dict):
         if len(optional_args) > 0:
-            values_list=list()
-            key=optional_args[0]
-            optional_args=optional_args[1:]
-            while (len(optional_args) > 0 ) and (not optional_args[0].startswith("--")):
+            values_list = list()
+            key = optional_args[0]
+            optional_args = optional_args[1:]
+            while (len(optional_args) > 0) and (not optional_args[0].startswith("--")):
                 values_list.append(optional_args[0])
-                optional_args=optional_args[1:]
-            current_dict[key]=values_list
-            return parse_optional_args(optional_args,current_dict)
+                optional_args = optional_args[1:]
+            current_dict[key] = values_list
+            return parse_optional_args(optional_args, current_dict)
         else:
             return current_dict
 
     def find_optional_args(args):
         """ Re-organize args to put a dictionary first as the optional arguments
         args=['tract_math', '/tmp/proj/subj/session/t1.vtp','/tmp/proj/subj/session/t2.vtp',
-               '--FileNames','-1','-2','-3','--AnotherOption']
+               '--file_names','-1','-2','-3','--another_option']
         new_args=find_optional_args(args)
         print(new_args)
-        [{'--FileNames': ['-1', '-2', '-3'], '--AnotherOption': []},
+        [{'--file_names': ['-1', '-2', '-3'], '--another_option': []},
              'tract_math', '/tmp/proj/subj/session/t1.vtp', '/tmp/proj/subj/session/t2.vtp']
         """
-        base_args=args
-        optional_args=list()
+        base_args = args
+        optional_args = list()
         for index in range(len(args)):
-            if isinstance(args[index],basestring) and args[index].startswith("--"):
+            if isinstance(args[index], basestring) and args[index].startswith("--"):
                 base_args = args[:index]
                 optional_args = args[index:]
                 break
-        options_dict = parse_optional_args(optional_args,dict())
-        return base_args,options_dict
+        options_dict = parse_optional_args(optional_args, dict())
+        return base_args, options_dict
 
     def internal_decorator(func):
         def wrapper(*input_args):
             # find optional flags and put them as a dictionary
             # at the beginning of args
-            args,options_dict=find_optional_args(input_args)
+            args, options_dict = find_optional_args(input_args)
 
             total_args = len(args)
             argspec = inspect.getargspec(func)
-            func_total_args = len(argspec.args) - 1 # Subtract 1 for implicit options_dict
+            # Subtract 1 for implicit options_dict
+            func_total_args = len(argspec.args) - 1
 
             if argspec.varargs:
                 func_total_args += 1
@@ -82,19 +83,21 @@ def tract_math_operation(help_text, needs_one_tract=True):
                 has_file_output
             ):
                 if has_file_output:
-                    ix = argspec.args.index('file_output') - 1 # Subtract 1 for implicit options_dict
+                    # Subtract 1 for implicit options_dict
+                    ix = argspec.args.index('file_output') - 1
 
                     if ix >= len(args):
                         raise TractMathWrongArgumentsError(
-                            'Wrong number of parameters for the operation:\n'+
-                            str(args)+"\n"+str(ix) + " != " + str(len(args))
+                            'Wrong number of parameters for the operation:\n' +
+                            str(args) + "\n" + str(ix) +
+                            " != " + str(len(args))
                         )
                     file_output = args[ix]
                 else:
                     file_output = args[-1]
                     args = args[:-1]
 
-                option_and_args=(options_dict,)+args
+                option_and_args = (options_dict,) + args
                 out = func(*option_and_args)
 
                 process_output(out, file_output=file_output)
@@ -105,7 +108,7 @@ def tract_math_operation(help_text, needs_one_tract=True):
                 if args[-1] == '-':
                     args = args[:-1]
 
-                option_and_args=(options_dict,)+args
+                option_and_args = (options_dict,) + args
                 process_output(func(*option_and_args))
             else:
                 raise TractMathWrongArgumentsError(

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -25,12 +25,47 @@ def tract_math_operation(help_text, needs_one_tract=True):
     needs_one_tract: tells the script if all the input tractographies should
                       be unified as one or left as a tractography list
     '''
+    def parse_optional_args(optional_args,current_dict):
+        if len(optional_args) > 0:
+            values_list=list()
+            key=optional_args[0]
+            optional_args=optional_args[1:]
+            while (len(optional_args) > 0 ) and (not optional_args[0].startswith("--")):
+                values_list.append(optional_args[0])
+                optional_args=optional_args[1:]
+            current_dict[key]=values_list
+            return parse_optional_args(optional_args,current_dict)
+        else:
+            return current_dict
+
+    def find_optional_args(args):
+        """ Re-organize args to put a dictionary first as the optional arguments
+        args=['tract_math', '/tmp/proj/subj/session/t1.vtp','/tmp/proj/subj/session/t2.vtp',
+               '--FileNames','-1','-2','-3','--AnotherOption']
+        new_args=find_optional_args(args)
+        print(new_args)
+        [{'--FileNames': ['-1', '-2', '-3'], '--AnotherOption': []},
+             'tract_math', '/tmp/proj/subj/session/t1.vtp', '/tmp/proj/subj/session/t2.vtp']
+        """
+        base_args=args
+        optional_args=list()
+        for index in range(len(args)):
+            if isinstance(args[index],basestring) and args[index].startswith("--"):
+                base_args = args[:index]
+                optional_args = args[index:]
+                break
+        options_dict = parse_optional_args(optional_args,dict())
+        return base_args,options_dict
 
     def internal_decorator(func):
-        def wrapper(*args):
+        def wrapper(*input_args):
+            # find optional flags and put them as a dictionary
+            # at the beginning of args
+            args,options_dict=find_optional_args(input_args)
+
             total_args = len(args)
             argspec = inspect.getargspec(func)
-            func_total_args = len(argspec.args)
+            func_total_args = len(argspec.args) - 1 # Subtract 1 for implicit options_dict
 
             if argspec.varargs:
                 func_total_args += 1
@@ -47,18 +82,20 @@ def tract_math_operation(help_text, needs_one_tract=True):
                 has_file_output
             ):
                 if has_file_output:
-                    ix = argspec.args.index('file_output')
+                    ix = argspec.args.index('file_output') - 1 # Subtract 1 for implicit options_dict
 
                     if ix >= len(args):
                         raise TractMathWrongArgumentsError(
-                            'Wrong number of parameters for the operation'
+                            'Wrong number of parameters for the operation:\n'+
+                            str(args)+"\n"+str(ix) + " != " + str(len(args))
                         )
                     file_output = args[ix]
                 else:
                     file_output = args[-1]
                     args = args[:-1]
 
-                out = func(*args)
+                option_and_args=(options_dict,)+args
+                out = func(*option_and_args)
 
                 process_output(out, file_output=file_output)
             elif (
@@ -67,10 +104,13 @@ def tract_math_operation(help_text, needs_one_tract=True):
             ):
                 if args[-1] == '-':
                     args = args[:-1]
-                process_output(func(*args))
+
+                option_and_args=(options_dict,)+args
+                process_output(func(*option_and_args))
             else:
                 raise TractMathWrongArgumentsError(
                     'Wrong number of arguments for the operation'
+                    + str(args) + "\n"
                 )
 
         wrapper.help_text = help_text


### PR DESCRIPTION
This patch provide possibility to add optional
flags to tract_math.

Optional flags are always start with "--" and
are considered as boolean flags.

This patch shold be backwards compatible, and previous results
should be created if not options are specified.

A newly added optional flag is "--useFileNamesAsIndex".
When this flag is used, the created csv output table uses
tractography file names instead of index IDs.

The --useFileNamesAsIndex col_name1:path_dir_index col_name2:path_dir_index2 .. col_nameN:path_dir_indexN

Example directory layout:
=========================
PROJ_XX/SUBJ_01/SESSION_AB/cm1.left.vtp
PROJ_XX/SUBJ_01/SESSION_AB/cm1.right.vtp
||||||| ||||||| |||||||||| ||||||||||||||||||||||||
4444444 3333333 2222222222 111111111111111111111111

tract_math call:
================
tract_math PROJ_XX/SUBJ_01/SESSION_AB/*.vtp count test.csv --useFileNamesAsIndex proj:4 subj:3 sess:2 tract:1

result:
=======
$ cat test.csv
sess,number of tracts,subj,proj,tract
SESSION_AB,176,SUBJ_01,PROJ_XX,cm1.left.vtp
SESSION_AB,88,SUBJ_01,PROJ_XX,cm1.right.vtp