### PR TITLE
BUG: RD incorrectly computed with axial_diffusivity

### DIFF
--- a/tract_querier/tract_math/tensor_operations.py
+++ b/tract_querier/tract_math/tensor_operations.py
@@ -129,7 +129,7 @@ def decorate_tract_with_measures(tractography, tensor_name):
             fa_by_point[index] = scalar_measures.fractional_anisotropy_from_eigenvalues(eigenvals)
             md_by_point[index] = scalar_measures.mean_diffusivity(eigenvals)
             ax_by_point[index] = scalar_measures.axial_diffusivity(eigenvals)
-            rd_by_point[index] = scalar_measures.axial_diffusivity(eigenvals)
+            rd_by_point[index] = scalar_measures.radial_diffusivity(eigenvals)
             ga_by_point[index] = scalar_measures.geodesic_anisotropy(eigenvals)
             index = index + 1
         fa_fiber_list.append(fa_by_point)


### PR DESCRIPTION
OK   md_by_point[index] = scalar_measures.mean_diffusivity(eigenvals)
OK   ax_by_point[index] = scalar_measures.axial_diffusivity(eigenvals)
BUG  rd_by_point[index] = scalar_measures.axial_diffusivity(eigenvals)
                                          ^^^^^^^^^^^^^^^^^
OK   ga_by_point[index] = scalar_measures.geodesic_anisotropy(eigenvals)

Clearly this is a bug.  All the AX measures are correct, all the RD
measures are wrong for these results.

resolves: #27