### PR TITLE
DOC: Incorrect documentation for use_file_names_as_index

### DIFF
--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -53,7 +53,7 @@ def main():
 
         tract_math call:
         ================
-        tract_math PROJ_XX/SUBJ_01/SESSION_AB/*.vtp count test.csv --useFileNamesAsIndex proj:4 subj:3 sess:2 tract:1
+        tract_math PROJ_XX/SUBJ_01/SESSION_AB/*.vtp count test.csv --use_file_names_as_index proj:4 subj:3 sess:2 tract:1
 
         result:
         =======


### PR DESCRIPTION
The flag --useFileNamesAsIndex was changed in the code to
--use_file_names_as_index.  This will require all scripts
that use this feature to be rewritten.  It is currently
silently doing the wrong behavior rather than producing a
meaningful failure message.