### PR TITLE
Update freesurfer_queries_bsf2016.qry

### DIFF
--- a/tract_querier/data/freesurfer_queries_bsf2016.qry
+++ b/tract_querier/data/freesurfer_queries_bsf2016.qry
@@ -360,6 +360,6 @@ striato_parietal.side = (
 )
 
 #Striato-occipital
-striato_parietal.side = (
+striato_occipital.side = (
     endpoints_in(striatum.side) and endpoints_in(occipital.side)
 )


### PR DESCRIPTION
in line 363, striato-parietal.side was overwritten by what actually should be striato-occipital