### PR TITLE
FIX: find_queries_path() now explores all sysconfig schemes

### DIFF
--- a/tract_querier/__init__.py
+++ b/tract_querier/__init__.py
@@ -8,8 +8,11 @@ from . import tractography
 
 
 def find_queries_path():
-    default_path = sysconfig.get_path(name='data')
-    possible_paths = [os.path.join(default_path, 'tract_querier', 'queries')]
+    possible_paths = []
+    # Try all possible schemes where python expects data to stay.
+    for scheme in sysconfig.get_scheme_names():
+        default_path = sysconfig.get_path(name='data', scheme=scheme)
+        possible_paths.append(os.path.join(default_path, 'tract_querier', 'queries'))
 
     # Try to manage Virtual Environments on some OSes,
     # where data is not put the 'local' subdirectory,


### PR DESCRIPTION
When installing tract_querier in non-system folders, e.g. with `python setup.py install --user`, tract_querier is unable to find the queries and triggers `Exception: Default path for queries not found` and immediately stop working. The issue is in `find_queries_path()`, where `sysconfig.get_path()` uses only the default scheme, see: [https://docs.python.org/3/library/sysconfig.html#installation-paths](url). This patch fixes the issue by looping through all schemes supported by Python. See issue #39.