### PR TITLE
Added roi_querier script - No functionallity yet

### DIFF
--- a/scripts/roi_querier
+++ b/scripts/roi_querier
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import argparse
+import tract_querier
+
+import nibabel
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""Creates volumetric ROIs to be used as seed, waypoint and
+                       exclusion masks in different tractography software"""
+    )
+    parser.add_argument("atlas", help="volume file representing the atlas",
+                        type=str)
+    parser.add_argument("queries_string", help="query to run", type=str)
+    parser.add_argument("outdir", help="directory where to output files",
+                        type=str)
+
+    # Make the interface compatible with tract_querier
+    parser.add_argument("-a", "--atlas", dest="atlas",
+                        help="name of the atlas file")
+    parser.add_argument("-q", "--queries", dest="queries_string",
+                        help="query to run")
+    parser.add_argument('-o', "--output", dest="outdir",
+                        help="folder in which to output the ROIs")
+
+    args = parser.parse_args()
+
+    query_file_body, _, _ = tract_querier.search_file_and_create_query_body(
+            args.queries_string
+    )
+
+    # TODO:
+    # eval_queries_roi
+    # save results
+    return
+
+
+def save_query(query_name, reference, outdir, evaluated_queries):
+    raise NotImplementedError()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tract_querier
+++ b/scripts/tract_querier
@@ -74,65 +74,9 @@ def main():
         bounding_box_affine_transform = None
 
     print("Loading files")
-
-    # Search order precidence for .qry files
-    # 1. Command line options specified are respected first
-    # 2. Current directory is respected second
-    # 3. Default query location thrid
-    # 4. Source Tree 4th
-    qry_search_folders = []
-    if options.include:
-        command_line_qry_folders = options.include.split(':')
-        ## Check that all commandline provided folders are valid paths
-        for folder in command_line_qry_folders:
-            if not (os.path.exists(folder) and os.path.isdir(folder)):
-                parser.error("Error in include folder %s" % folder)
-        qry_search_folders.extend(command_line_qry_folders)
-
-    qry_search_folders.extend([os.getcwd()])
-
-    if os.path.exists(tract_querier.default_queries_folder):
-        qry_search_folders.extend([tract_querier.default_queries_folder])
-
-    ## Source Tree Data
-    source_tree_data_path = os.path.abspath(
-        os.path.join(
-        os.path.dirname(os.path.dirname(__file__)),
-        'tract_querier','data')
+    query_file_body, query_script, qry_search_folders = tract_querier.search_file_and_create_query_body(
+            options.queries_string
     )
-    if os.path.exists(source_tree_data_path):
-        qry_search_folders.extend([source_tree_data_path])
-
-
-    try:
-        if os.path.exists(options.queries_string):
-            query_script = open(options.queries_string).read()
-            query_filename = options.queries_string
-        else:
-            found = False
-            for folder in qry_search_folders:
-                file_ = os.path.join(folder, options.queries_string)
-                if os.path.exists(file_):
-                    found = True
-                    break
-            if found:
-                query_script = open(file_).read()
-                query_filename = file_
-            else:
-                query_script = options.queries_string
-                query_filename = '<script>'
-
-        query_file_body = tract_querier.queries_preprocess(
-            query_script,
-            filename=query_filename,
-            include_folders=qry_search_folders
-        )
-
-        tract_querier.queries_syntax_check(query_file_body)
-    except tract_querier.TractQuerierSyntaxError or tract_querier.TractographySpatialIndexing as e:
-        parser.error(e.value)
-    # except tract_querier.TractographySpatialIndexing as e:
-    #     parser.error(e.value)
 
     labels_nii = nibabel.load(options.atlas_file_name)
     img = labels_nii.get_data()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ MAINTAINER_EMAIL = 'demian@bwh.harvard.edu'
 URL = 'http://demianw.github.io/tract_querier'
 LICENSE = open('license.rst').read()
 DOWNLOAD_URL = 'https://github.com/demianw/tract_querier'
-VERSION = '0.1'
+VERSION = '0.2'
 
 
 def configuration(parent_package='', top_path=None):
@@ -49,7 +49,8 @@ if __name__ == "__main__":
         ],
         scripts=[
             'scripts/tract_querier',
-            'scripts/tract_math'
+            'scripts/tract_math',
+            'scripts/roi_querier'
         ],
         test_suite='nose.collector',
         **(configuration().todict())

--- a/tract_querier/__init__.py
+++ b/tract_querier/__init__.py
@@ -12,7 +12,8 @@ def find_queries_path():
     # Try all possible schemes where python expects data to stay.
     for scheme in sysconfig.get_scheme_names():
         default_path = sysconfig.get_path(name='data', scheme=scheme)
-        possible_paths.append(os.path.join(default_path, 'tract_querier', 'queries'))
+        possible_paths.append(os.path.join(default_path, 'tract_querier',
+                                           'queries'))
 
     # Try to manage Virtual Environments on some OSes,
     # where data is not put the 'local' subdirectory,
@@ -34,6 +35,64 @@ def find_queries_path():
     return paths_found[0]
 
 
+def search_file_and_create_query_body(queries_string):
+    # Search order precidence for .qry files
+    # 1. Current directory
+    # 2. Command line options specified are respected second
+    # 3. Default query location thrid
+    # 4. Source Tree 4th
+    qry_search_folders = []
+    qry_search_folders.extend([os.getcwd()])
+    default_queries_folder = find_queries_path()
+
+    if os.path.exists(default_queries_folder):
+        qry_search_folders.extend([default_queries_folder])
+
+    # Source Tree Data
+    source_tree_data_path = os.path.abspath(
+        os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                     'tract_querier', 'data')
+    )
+    if os.path.exists(source_tree_data_path):
+        qry_search_folders.extend([source_tree_data_path])
+    
+    found = False
+    try:
+        if os.path.exists(queries_string):
+            query_script = open(queries_string).read()
+            query_filename = queries_string
+        else:
+            found = False
+            for folder in qry_search_folders:
+                file_ = os.path.join(folder, queries_string)
+                if os.path.exists(file_):
+                    found = True
+                    break
+            if found:
+                query_script = open(file_).read()
+                query_filename = file_
+            else:
+                query_script = queries_string
+                query_filename = '<script>'
+
+        query_file_body = queries_preprocess(
+            query_script,
+            filename=query_filename,
+            include_folders=qry_search_folders
+        )
+
+        queries_syntax_check(query_file_body)
+    except TractQuerierSyntaxError or TractographySpatialIndexing as e:
+        if not found:
+            raise ValueError(f"The file {queries_string} does not exist")
+
+        raise ValueError("Error parsing the query file")
+    # except tract_querier.TractographySpatialIndexing as e:
+    #     parser.error(e.value)
+
+    return query_file_body, query_script, qry_search_folders
+
+
 default_queries_folder = find_queries_path()
 
-__version__ = 0.1
+__version__ = 0.2

--- a/tract_querier/data/freesurfer_queries_bsf2016.qry
+++ b/tract_querier/data/freesurfer_queries_bsf2016.qry
@@ -1,7 +1,7 @@
 import FreeSurfer.qry
 
 # Author: Demian Wassermann and Christophe Bedetti
-# Co-Authors: Catherine Vien, Arnaud Boré
+# Co-Authors: Catherine Vien, Arnaud Bore
 
 HEMISPHERE.left |= '*.left'
 HEMISPHERE.right |= '*.right'

--- a/tract_querier/data/freesurfer_queries_bsf2016_toad.qry
+++ b/tract_querier/data/freesurfer_queries_bsf2016_toad.qry
@@ -3,7 +3,7 @@ import freesurfer_queries_bsf2016.qry
 
 # 2016-09-01
 # Author: Christophe Bedetti
-# Co-Authors: Catherine Vien, Arnaud Boré
+# Co-Authors: Catherine Vien, Arnaud Bore
 # Exclusion queries added to perform with algorithms used in
 # TOAD (https://github.com/UNFmontreal/toad)
 

--- a/tract_querier/tests/test_scripts.py
+++ b/tract_querier/tests/test_scripts.py
@@ -22,6 +22,11 @@ TRACT_MATH_SCRIPT = path.join(
     'scripts', 'tract_math'
 )
 
+ROI_QUERIER_SCRIPT = path.join(
+    PACKAGE_ROOT_DIR,
+    'scripts', 'roi_querier'
+)
+
 PYTHON = sys.executable
 
 ENVIRON = os.environ.copy()
@@ -29,6 +34,7 @@ sys.path.insert(0, PACKAGE_ROOT_DIR)
 ENVIRON['PYTHONPATH'] = reduce(lambda x, y: '%s:%s' % (x, y), sys.path)
 
 TEST_DATA = datasets.TestDataSet()
+
 
 def test_tract_querier_help():
     popen = subprocess.Popen(
@@ -41,6 +47,19 @@ def test_tract_querier_help():
     assert_in('error: incorrect number of arguments', stderr_text)
     assert_greater(popen.returncode, 0)
 
+
+def test_roi_querier_help():
+    popen = subprocess.Popen(
+        [PYTHON, ROI_QUERIER_SCRIPT],
+        shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=ENVIRON
+    )
+    popen.wait()
+    stderr_text = ''.join(popen.stderr.readlines())
+    assert_in('error: incorrect number of arguments', stderr_text)
+    assert_greater(popen.returncode, 0)
+
+
 def test_tract_math_help():
     popen = subprocess.Popen(
         [PYTHON, TRACT_MATH_SCRIPT],
@@ -52,6 +71,7 @@ def test_tract_math_help():
     assert_in('error: too few arguments', stderr_text)
     assert_greater(popen.returncode, 0)
 
+
 def test_tract_math_count():
     popen = subprocess.Popen(
         [PYTHON, TRACT_MATH_SCRIPT, TEST_DATA.files['tract_file'], 'count'],
@@ -62,6 +82,7 @@ def test_tract_math_count():
     stdout_text = ''.join(popen.stdout.readlines())
     assert_is_not_none(re.search('[^0-9]6783[^0-9]', stdout_text))
     assert_equal(popen.returncode, 0)
+
 
 def test_tract_querier_query():
     output_prefix = '%s/test' % TEST_DATA.dirname


### PR DESCRIPTION
This commit prepares the repository to welcome the new script
"roi_querier". Some small errors were also fixed. The main changes are:

1. The code that parses/transforms a query into a tree has been
   removed from scripts/tract_querier and made into a function:
   search_file_and_create_query_body. It is located in the file
   tract_querier/__init__.py. This allows us to share the query-parsing
   in both "roi_querier" and "tract_querier".

2. The function to parse the queries now returns a "file not found"
   error when the file.qry does not exists. This is much more
   informative than the current "error in query file"

3. The test were givin some encoding-related errors with the files
   freesurfer_queries_bsf2016*. This have been fixed.