### PR TITLE
ENH: Update Python versions in TravisCI job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dist: xenial
 sudo: required
 matrix:
   include:
-    - python: "2.7"
-    - python: "3.5"
-    - python: "3.6"
-    - python: "3.7"
+    - python: "3.9"
+    - python: "3.10"
+    - python: "3.11"
+    - python: "3.12"
   
 before_install:
     - deactivate


### PR DESCRIPTION
Update Python versions in TravisCI job matrix: discontinue testing on Python 2.7, 3.5, 3.6, and 3.7 as they all have reached their EOL and test on 3.9, 3.10, 3.11 and 3.12:
https://devguide.python.org/versions/