### PR TITLE
ENH: Add GHA build status badge to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 Welcome to WMQL's source code!
 =========================================
 
+[![test, package](https://github.com/demianw/tract_querier/actions/workflows/test_package.yaml/badge.svg)](https://github.com/demianw/tract_querier/actions/workflows/test_package.yaml)
+
 The White Matter Query Language (WMQL) is a technique to formally describe white matter tracts and to automatically extract them from diffusion MRI volumes. This query language allows us to construct a dictionary of anatomical definitions describing white matter tracts. The definitions include adjacent gray and white matter regions, and rules for spatial relations. This enables the encoding of anatomical knowledge of the human brain white matter as well as the automated coherent labeling of white matter anatomy across subjects.
 
 This is an implementation of the WMQL language presented in ["The white matter query language: a novel approach for describing human white matter anatomy", Wassermann et al. Brain Structure and Function 2016](http://link.springer.com/article/10.1007%2Fs00429-015-1179-4)
 
  [WMQL Documentation](http://demianw.github.io/tract_querier "WMQL Documentation")
-
-Automated testing status: 
-[![travis-ci build status](https://secure.travis-ci.org/demianw/tract_querier.png?branch=master)](http://travis-ci.org/demianw/tract_querier)
-    


### PR DESCRIPTION
Add GHA build status badge to `README` and remove the TravisCI build link as it is no longer active.