### PR TITLE
ENH: Transition to more modern versions of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 dependencies = [
-    "numpy>=1.19.5,<2.0.0",
-    "nibabel>=2.0,<3.0",
+    "numpy>=1.23.0,<2.0.0",
+    "nibabel>=3.0.0",
     "six>=1.10",
     "vtk"
 ]


### PR DESCRIPTION
Transition to more modern versions of dependencies:
- Require `NumPy` equal or greater than 1.23.0.
- Require `NiBabel` equal or greater than 3.0.0.

`NiBabel` 3.0.0 still has the `trackvis` module support, and the minimum previous version of `NumPy` (1.21.0) did not work locally, deadlocking in the tractography testing suite.