### PR TITLE
ENH: Use `pytest` for testing instead of `nose`

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -59,4 +59,4 @@ jobs:
 
     - name: Run tests
       run: |
-        nosetests -v
+        pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ doc = [
 ]
 test = [
     "coverage",
-    "nose",
+    "pytest",
 ]
 
 [project.urls]

--- a/tract_querier/tests/test_query_eval.py
+++ b/tract_querier/tests/test_query_eval.py
@@ -1,5 +1,4 @@
 from .. import query_processor
-from nose.tools import assert_true, assert_equal
 
 from numpy import random
 import ast
@@ -39,7 +38,7 @@ empty_spatial_indexing = DummySpatialIndexing({}, {}, ({}, {}), ({}, {}), {}, {}
 def test_assign():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0] and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -49,7 +48,7 @@ def test_assign():
 def test_assign_attr():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("a.left=0"))
-    assert_true((
+    assert ((
         'a.left' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['a.left'].tracts == labels_tracts[0] and
         query_evaluator.evaluated_queries_info['a.left'].labels == set((0,))
@@ -87,8 +86,8 @@ a.side = b.side or c.opposite
 
     query_evaluator.visit(ast.parse(query))
 
-    assert_equal({k: v.labels for k, v in query_evaluator.evaluated_queries_info.items()}, queries_labels)
-    assert_equal({k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()}, queries_tracts)
+    assert {k: v.labels for k, v in query_evaluator.evaluated_queries_info.items()} == queries_labels
+    assert {k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()} == queries_tracts
 
 
 def test_assign_str():
@@ -120,8 +119,8 @@ h = '*left'
 
     query_evaluator.visit(ast.parse(query))
 
-    assert_equal({k: v.labels for k, v in query_evaluator.evaluated_queries_info.items()}, queries_labels)
-    assert_equal({k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()}, queries_tracts)
+    assert {k: v.labels for k, v in query_evaluator.evaluated_queries_info.items()} == queries_labels
+    assert {k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()} == queries_tracts
 
 
 def test_for_list():
@@ -151,7 +150,7 @@ for i in [a,b,c,d,e]: i.right = i.left
 
     query_evaluator.visit(ast.parse(query))
 
-    assert_equal({k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()}, queries_tracts)
+    assert {k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()} == queries_tracts
 
 
 def test_for_str():
@@ -181,13 +180,13 @@ for i in '*left': i.right = i
 
     query_evaluator.visit(ast.parse(query))
 
-    assert_equal({k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()}, queries_tracts)
+    assert {k: v.tracts for k, v in query_evaluator.evaluated_queries_info.items()} == queries_tracts
 
 
 def test_add():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0+1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].union(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0, 1))
@@ -197,7 +196,7 @@ def test_add():
 def test_mult():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0 * 1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].intersection(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0, 1))
@@ -207,7 +206,7 @@ def test_mult():
 def test_sub():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=(0 + 1) - 1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].difference(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -217,7 +216,7 @@ def test_sub():
 def test_or():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0 or 1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].union(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0, 1))
@@ -227,7 +226,7 @@ def test_or():
 def test_and():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0 and 1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].intersection(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0, 1))
@@ -237,7 +236,7 @@ def test_and():
 def test_not_in():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0 or 1 not in 1"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0].difference(labels_tracts[1]) and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -247,7 +246,7 @@ def test_not_in():
 def test_only_sign():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=~0"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == tract_in_label_0_uniquely and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -257,7 +256,7 @@ def test_only_sign():
 def test_only():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=only(0)"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == tract_in_label_0_uniquely and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -267,7 +266,7 @@ def test_only():
 def test_unsaved_query():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A|=0"))
-    assert_true((
+    assert ((
         'A' not in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == labels_tracts[0] and
         query_evaluator.evaluated_queries_info['A'].labels == set((0,))
@@ -277,7 +276,7 @@ def test_unsaved_query():
 def test_symbolic_assignment():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A=0; B=A"))
-    assert_true((
+    assert ((
         'B' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['B'].tracts == labels_tracts[0] and
         query_evaluator.evaluated_queries_info['B'].labels == set((0,))
@@ -287,7 +286,7 @@ def test_symbolic_assignment():
 def test_unarySub():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("B=0; A=-B"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == tracts_in_all_but_0 and
         query_evaluator.evaluated_queries_info['A'].labels == set(labels_tracts.keys()).difference((0,))
@@ -297,7 +296,7 @@ def test_unarySub():
 def test_not():
     query_evaluator = query_processor.EvaluateQueries(dummy_spatial_indexing)
     query_evaluator.visit(ast.parse("A= not 0"))
-    assert_true((
+    assert ((
         'A' in query_evaluator.queries_to_save and
         query_evaluator.evaluated_queries_info['A'].tracts == tracts_in_all_but_0 and
         query_evaluator.evaluated_queries_info['A'].labels == set(labels_tracts.keys()).difference((0,))

--- a/tract_querier/tests/test_query_files.py
+++ b/tract_querier/tests/test_query_files.py
@@ -1,19 +1,22 @@
 from .. import queries_preprocess, queries_syntax_check
-from nose.tools import nottest
 
 import os
 import fnmatch
+import pytest
 
 
-def test_query_files(
-    folder=os.path.join(os.path.dirname(__file__), '..', 'data')
-):
-    files = fnmatch.filter(os.listdir(folder), '*qry')
-    for f in files:
-        yield query_file_test, os.path.join(folder, f), [folder]
+@pytest.fixture
+def data_folder():
+    return os.path.join(os.path.dirname(__file__), '..', 'data')
+
+@pytest.mark.parametrize("filename", [
+    pytest.param(os.path.join(os.path.join(os.path.dirname(__file__), '..', 'data'), f), id=f)
+    for f in fnmatch.filter(os.listdir(os.path.join(os.path.dirname(__file__), '..', 'data')), '*qry')
+])
+def test_query_files(data_folder, filename):
+    query_file_test(filename, [data_folder])
 
 
-@nottest
 def query_file_test(filename, include_folders):
     buf = open(filename).read()
     query_body = queries_preprocess(

--- a/tract_querier/tests/test_query_rewrite.py
+++ b/tract_querier/tests/test_query_rewrite.py
@@ -4,10 +4,6 @@ import pytest
 
 import ast
 
-import parser
-import token
-import symbol
-
 
 def match(pattern, data, vars=None):
     if vars is None:

--- a/tract_querier/tests/test_query_rewrite.py
+++ b/tract_querier/tests/test_query_rewrite.py
@@ -1,7 +1,6 @@
 from .. import query_processor
 
-from nose.tools import assert_equal, assert_not_equal
-from unittest import expectedFailure, skip
+import pytest
 
 import ast
 
@@ -27,7 +26,7 @@ def match(pattern, data, vars=None):
     return same, vars
 
 
-@skip
+@pytest.mark.skip()
 def test_rewrite_notin_precedence():
     code1 = "a and b not in c"
     code2 = "(a and b) not in c"
@@ -48,10 +47,10 @@ def test_rewrite_notin_precedence():
     rw.visit(tree2_rw)
     rw.visit(tree3_rw)
 
-    assert_not_equal(ast.dump(tree1), ast.dump(tree2))
-    assert_equal(ast.dump(tree2), ast.dump(tree2_rw))
-    assert_equal(ast.dump(tree1_rw), ast.dump(tree2))
+    assert ast.dump(tree1) != ast.dump(tree2)
+    assert ast.dump(tree2) == ast.dump(tree2_rw)
+    assert ast.dump(tree1_rw) == ast.dump(tree2)
 
-    assert_equal(ast.dump(tree3), ast.dump(tree3_rw))
+    assert ast.dump(tree3) == ast.dump(tree3_rw)
 
-    assert_equal(ast.dump(tree1), ast.dump(tree3_rw))
+    assert ast.dump(tree1) == ast.dump(tree3_rw)

--- a/tract_querier/tests/test_scripts.py
+++ b/tract_querier/tests/test_scripts.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equal, assert_greater, assert_in, assert_is_not_none, assert_true
-
 import os
 from os import path
 import re
@@ -38,8 +36,8 @@ def test_tract_querier_help():
     )
     popen.wait()
     stderr_text = ''.join(popen.stderr.readlines())
-    assert_in('error: incorrect number of arguments', stderr_text)
-    assert_greater(popen.returncode, 0)
+    assert 'error: incorrect number of arguments' in stderr_text
+    assert popen.returncode > 0
 
 def test_tract_math_help():
     popen = subprocess.Popen(
@@ -49,8 +47,8 @@ def test_tract_math_help():
     )
     popen.wait()
     stderr_text = ''.join(popen.stderr.readlines())
-    assert_in('error: too few arguments', stderr_text)
-    assert_greater(popen.returncode, 0)
+    assert 'error: too few arguments' in stderr_text
+    assert popen.returncode > 0
 
 def test_tract_math_count():
     popen = subprocess.Popen(
@@ -60,8 +58,8 @@ def test_tract_math_count():
     )
     popen.wait()
     stdout_text = ''.join(popen.stdout.readlines())
-    assert_is_not_none(re.search('[^0-9]6783[^0-9]', stdout_text))
-    assert_equal(popen.returncode, 0)
+    assert re.search('[^0-9]6783[^0-9]', stdout_text) is not None
+    assert popen.returncode == 0
 
 def test_tract_querier_query():
     output_prefix = '%s/test' % TEST_DATA.dirname
@@ -74,9 +72,9 @@ def test_tract_querier_query():
     )
     popen.wait()
     stdout_text = ''.join(popen.stdout.readlines())
-    assert_in('uncinate.left: 000102', stdout_text)
-    assert_in('uncinate.right: 000000', stdout_text)
-    assert_true(path.exists(output_prefix + '_uncinate.left.trk'))
-    assert_equal(popen.returncode, 0)
+    assert 'uncinate.left: 000102' in stdout_text
+    assert 'uncinate.right: 000000' in stdout_text
+    assert path.exists(output_prefix + '_uncinate.left.trk')
+    assert popen.returncode == 0
     if path.exists(output_prefix + '_uncinate.left.trk'):
         os.remove(output_prefix + '_uncinate.left.trk')

--- a/tract_querier/tractography/tests/test_tractography.py
+++ b/tract_querier/tractography/tests/test_tractography.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     VTK = False
 
-from nose.tools import with_setup
+import pytest
 import copy
 from itertools import chain
 
@@ -61,7 +61,7 @@ def equal_tractography(a, b):
     )
 
 
-def setup(*args, **kwargs):
+def setup_module(*args, **kwargs):
     global dimensions
     global tracts
     global tracts_data
@@ -100,7 +100,6 @@ def setup(*args, **kwargs):
     tractography = Tractography(tracts, tracts_data)
 
 
-@with_setup(setup)
 def test_creation():
     assert(equal_tracts(tractography.tracts(), tracts))
     assert(equal_tracts_data(tractography.tracts_data(), tracts_data))
@@ -108,7 +107,6 @@ def test_creation():
     assert(not tractography.are_tracts_filtered())
 
 
-@with_setup(setup)
 def test_subsample_tracts():
     tractography.subsample_tracts(5)
 
@@ -133,7 +131,6 @@ def test_subsample_tracts():
     assert(not tractography.are_tracts_filtered())
 
 
-@with_setup(setup)
 def test_append():
     old_tracts = copy.deepcopy(tractography.tracts())
     new_data = {}
@@ -147,7 +144,6 @@ def test_append():
 
 
 if VTK:
-    @with_setup(setup)
     def test_saveload_vtk():
         import tempfile
         import os
@@ -164,7 +160,7 @@ if VTK:
 
         os.remove(fname)
 
-    @with_setup(setup)
+
     def test_saveload_vtp():
         import tempfile
         import os
@@ -179,7 +175,6 @@ if VTK:
         os.remove(fname)
 
 
-@with_setup(setup)
 def test_saveload_trk():
     import tempfile
     import os
@@ -208,7 +203,6 @@ def test_saveload_trk():
     os.remove(fname)
 
 
-@with_setup(setup)
 def test_saveload():
     import tempfile
     import os


### PR DESCRIPTION
Use `pytest` for testing instead of `nose`: `nose` is no longer maintained and its successor maintainers `nose2` encourage to use `pytest` as it as a bigger team of maintainers and a larger community of users.

Avoids errors that stem from using `nose` as the testing tool:
```
AttributeError: module 'collections' has no attribute 'Callable'
```

raised for example in:
https://github.com/demianw/tract_querier/actions/runs/12168541455/job/33939552914#step:6:37

Documentation:
https://github.com/nose-devs/nose2
https://docs.pytest.org/en/latest/