### PR TITLE
ENH: Require `NumPy` greater or equal to 1.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 dependencies = [
-    "numpy>=1.23.0,<2.0.0",
+    "numpy>=1.26.0,<2.0.0",
     "nibabel>=3.0.0",
     "six>=1.10",
     "vtk"


### PR DESCRIPTION
Require `NumPy` greater or equal to 1.26.0: 1.26.0 is the first release that supported Python 3.12 and supports versions 3.9-3.12.

Documentation:
https://github.com/numpy/numpy/releases/tag/v1.26.0