### PR TITLE
ENH: Do not import `range` from `six`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "numpy>=1.23.0,<2.0.0",
     "nibabel>=3.0.0",
-    "six>=1.10",
     "vtk"
 ]
 dynamic = ["version"]

--- a/tract_querier/tract_label_indices.py
+++ b/tract_querier/tract_label_indices.py
@@ -1,10 +1,6 @@
 import warnings
 
-from six.moves import range
-
 import numpy as np
-
-from six.moves import range
 
 from .aabb import BoundingBox
 

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -5,8 +5,6 @@ import io
 import csv
 from os import path
 
-from six.moves import range
-
 import nibabel
 
 from ..tractography import (

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -1,7 +1,5 @@
 from .decorator import tract_math_operation, set_dictionary_from_use_filenames_as_index
 
-from six.moves import range
-
 from warnings import warn
 
 import numpy

--- a/tract_querier/tractography/trackvis.py
+++ b/tract_querier/tractography/trackvis.py
@@ -1,5 +1,4 @@
 from warnings import warn
-from six.moves import range
 
 import numpy
 
@@ -43,7 +42,7 @@ def tractography_to_trackvis_file(filename, tractography, affine=None, image_dim
     #data_new = {}
     # for k, v in data.iteritems():
     #    if (v[0].ndim > 1 and v[0].shape[1] > 1):
-    #        for i in xrange(v[0].shape[1]):
+    #        for i in range(v[0].shape[1]):
     #            data_new['%s_%02d' % (k, i)] = [
     #                v_[:, i] for v_ in v
     #            ]

--- a/tract_querier/tractography/tractography.py
+++ b/tract_querier/tractography/tractography.py
@@ -1,5 +1,4 @@
 import numpy as np
-from six.moves import range
 
 __all__ = ['Tractography']
 

--- a/tract_querier/tractography/vtkInterface.py
+++ b/tract_querier/tractography/vtkInterface.py
@@ -3,8 +3,6 @@ import vtk
 from vtk.util import numpy_support as ns
 import numpy as np
 
-from six.moves import range
-
 from .tractography import Tractography
 from functools import reduce
 


### PR DESCRIPTION
Do not import `range` from `six`: `six` is a Python 2 and 3 compatibility library. Since support for Python 2 was dropped following the discussion in https://github.com/demianw/tract_querier/pull/53, this patch set removes `six` as a dependency of the project.

The built-in Python `range()` is equivalent to the `six.moves.range` method, so adopt the former by avoiding to import it from `six.moves`.

Similarly, use `range()` instead of `xrange()`, which is only supported in Python 2. Both are equivalent.

Documentation:
https://pypi.org/project/six/