### PR TITLE
ENH: Use `NumPy` random generators

### DIFF
--- a/tract_querier/tensor/tests/test_scalar_measures.py
+++ b/tract_querier/tensor/tests/test_scalar_measures.py
@@ -4,8 +4,8 @@ import numpy
 from numpy.testing import assert_array_almost_equal
 
 
-def test_fractional_anisotropy(N=10, random=numpy.random.RandomState(0)):
-    tensors = random.randn(N, 3, 3)
+def test_fractional_anisotropy(N=10, random=numpy.random.default_rng(0)):
+    tensors = random.standard_normal((N, 3, 3))
     fa = numpy.empty(N)
     for i, t in enumerate(tensors):
         tt = numpy.dot(t, t.T)
@@ -17,8 +17,8 @@ def test_fractional_anisotropy(N=10, random=numpy.random.RandomState(0)):
     assert_array_almost_equal(fa, scalar_measures.fractional_anisotropy(tensors))
 
 
-def test_volume_fraction(N=10, random=numpy.random.RandomState(0)):
-    tensors = random.randn(N, 3, 3)
+def test_volume_fraction(N=10, random=numpy.random.default_rng(0)):
+    tensors = random.standard_normal((N, 3, 3))
     vf = numpy.empty(N)
     for i, t in enumerate(tensors):
         tt = numpy.dot(t, t.T)
@@ -30,8 +30,8 @@ def test_volume_fraction(N=10, random=numpy.random.RandomState(0)):
     assert_array_almost_equal(vf, scalar_measures.volume_fraction(tensors))
 
 
-def test_tensor_determinant(N=10, random=numpy.random.RandomState(0)):
-    tensors = random.randn(N, 3, 3)
+def test_tensor_determinant(N=10, random=numpy.random.default_rng(0)):
+    tensors = random.standard_normal((N, 3, 3))
     dt = numpy.empty(N)
     for i, t in enumerate(tensors):
         tt = numpy.dot(t, t.T)
@@ -41,8 +41,8 @@ def test_tensor_determinant(N=10, random=numpy.random.RandomState(0)):
     assert_array_almost_equal(dt, scalar_measures.tensor_det(tensors))
 
 
-def test_tensor_traces(N=10, random=numpy.random.RandomState(0)):
-    tensors = random.randn(N, 3, 3)
+def test_tensor_traces(N=10, random=numpy.random.default_rng(0)):
+    tensors = random.standard_normal((N, 3, 3))
     res = numpy.empty(N)
     for i, t in enumerate(tensors):
         tt = numpy.dot(t, t.T)
@@ -52,9 +52,9 @@ def test_tensor_traces(N=10, random=numpy.random.RandomState(0)):
     assert_array_almost_equal(res, scalar_measures.tensor_trace(tensors))
 
 
-def test_tensor_contraction(N=10, random=numpy.random.RandomState(0)):
-    tensors1 = random.randn(N, 3, 3)
-    tensors2 = random.randn(N, 3, 3)
+def test_tensor_contraction(N=10, random=numpy.random.default_rng(0)):
+    tensors1 = random.standard_normal((N, 3, 3))
+    tensors2 = random.standard_normal((N, 3, 3))
 
     res = numpy.empty(N)
     for i in range(N):

--- a/tract_querier/tests/test_query_eval.py
+++ b/tract_querier/tests/test_query_eval.py
@@ -1,12 +1,14 @@
 from .. import query_processor
 
-from numpy import random
 import ast
+import numpy as np
+
 
 # Ten tracts traversing random labels
 another_set = True
 while (another_set):
-    tracts_labels = dict([(i, set(random.randint(100, size=2))) for i in range(100)])
+    rng = np.random.default_rng()
+    tracts_labels = dict([(i, set(rng.integers(100, size=2))) for i in range(100)])
     labels_tracts = query_processor.labels_for_tracts(tracts_labels)
     another_set = 0 not in labels_tracts.keys() or 1 not in labels_tracts.keys()
 

--- a/tract_querier/tract_math/tract_obb.py
+++ b/tract_querier/tract_math/tract_obb.py
@@ -1007,13 +1007,14 @@ def draw_box_2d(obbs, **args):
 
 
 def draw_box_3d(obbs, tube_radius=1, color=None, **kwargs):
+        import numpy as np
         from mayavi.mlab import plot3d
-        from numpy.random import rand
+        rng = np.random.default_rng(1234)
         if isinstance(obbs, Box2D):
             obbs = [obbs]
         for obb in obbs:
             if color is None:
-                color_ = tuple(rand(3))
+                color_ = tuple(rng.random(3))
             else:
                 color_ = color
             box = obb.box

--- a/tract_querier/tractography/tests/test_tractography.py
+++ b/tract_querier/tractography/tests/test_tractography.py
@@ -16,8 +16,8 @@ import pytest
 import copy
 from itertools import chain
 
+import numpy as np
 from numpy import all, eye, ones, allclose
-from numpy.random import randint, randn
 from numpy.testing import assert_array_equal
 
 dimensions = None
@@ -72,14 +72,15 @@ def setup_module(*args, **kwargs):
     else:
         test_active_data = False
 
-    dimensions = [(randint(5, max_tract_length), 3) for _ in range(n_tracts)]
-    tracts = [randn(*d) for d in dimensions]
+    rng = np.random.default_rng(1234)
+    dimensions = [(rng.integers(5, max_tract_length), 3) for _ in range(n_tracts)]
+    tracts = [rng.standard_normal(d) for d in dimensions]
     tracts_data = {
         'a%d' % i: [
-            randn(d[0], k)
+            rng.standard_normal((d[0], k))
             for d in dimensions
         ]
-        for i, k in zip(range(4), randint(1, 3, 9))
+        for i, k in zip(range(4), rng.integers(1, 3, 9))
     }
 
     if test_active_data:


### PR DESCRIPTION
Use `NumPy` random generators as they are the preferred way to create random numbers since version 1.17.0.

Fix the seeds for the cases were they were not being fixed for the sake of reproducibility, except for `test_query_eval.py` where fixing the seed may make the `while` loop be infinite.

Documentation:
https://numpy.org/doc/1.17/reference/random/index.html