### PR TITLE
ENH: Report code coverage in CI

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -59,4 +59,9 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v
+        coverage run --source tract_querier -m pytest -v tract_querier
+
+    - name: Statistics
+      if: success()
+      run: |
+         coverage report


### PR DESCRIPTION
Report code coverage in CI: restores reporting coverage after dropping it in commit `035eebd` due to incompatibilities with the testing framework used at the time (`nose`). `nose` was replaced by `pytest` in commit e36ee38.