### PR TITLE
ENH: Restrict dependencies versions for release

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -19,7 +19,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
         requires: ['minimal', 'latest']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23.0,<2.0.0",
-    "nibabel>=3.0.0",
-    "vtk"
+    "nibabel>=3.0.0,<4.0.0",
+    "vtk>8.1.0,<=9.4.0"
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 
 [project.optional-dependencies]
 doc = [


### PR DESCRIPTION
Restrict dependencies versions for release.

Restrict the supported Python versions to those where the tool is known to be working (>=3.9, <3.12).