### PR TITLE
STYLE: Prefer using f-strings

### DIFF
--- a/tract_querier/aabb.py
+++ b/tract_querier/aabb.py
@@ -35,10 +35,7 @@ class BoundingBox(np.ndarray):
         return input_array.view(cls)
 
     def __str__(self):
-        return ('%s:%s' % (
-            super(np.ndarray, self[:3]).__str__(),
-            super(np.ndarray, self[3:]).__str__()
-        )).replace('BoundingBox', '')
+        return (f'{super(np.ndarray, self[:3]).__str__()}:{super(np.ndarray, self[3:]).__str__()}').replace('BoundingBox', '')
 
     @property
     def volume(self):
@@ -292,13 +289,10 @@ class AABBTree:
             self.parent = parent
 
         def __str__(self):
-            return """
-      box = %s
-      indices = %s
-      """ % (
-                self.box,
-                self.indices,
-            )
+            return f"""
+      box = {self.box}
+      indices = {self.indices}
+      """
 
         def __repr__(self):
             return self.__str__()
@@ -314,13 +308,10 @@ class AABBTree:
             self.parent = parent
 
         def __str__(self):
-            return """
-      box = %s
-      indices = %s
-      """ % (
-                self.box,
-                self.indices,
-            )
+            return f"""
+      box = {self.box}
+      indices = {self.indices}
+      """
 
         def __repr__(self):
             return self.__str__()

--- a/tract_querier/nipype/utils.py
+++ b/tract_querier/nipype/utils.py
@@ -223,9 +223,7 @@ class GenWarpFields(utils.ANTSCommand):
                     self._internal['input_images'],
                     self._internal['metric_weights'],
                 ):
-                    arg_string += '-m CC[%s,%s,%0.2f,4] ' % (
-                        template, reference, weight
-                    )
+                    arg_string += f'-m CC[{template},{reference},{weight:0.2f},4] '
                 return arg_string[:-1]
             else:
                 return ''

--- a/tract_querier/query_processor.py
+++ b/tract_querier/query_processor.py
@@ -161,8 +161,7 @@ class EvaluateQueries(ast.NodeVisitor):
     def visit_Compare(self, node):
         if any(not isinstance(op, ast.NotIn) for op in node.ops):
             raise TractQuerierSyntaxError(
-                "Invalid syntax in query line %d" % node.lineno
-            )
+                f"Invalid syntax in query line {node.lineno}")
 
         query_info = self.visit(node.left).copy()
         for value in node.comparators:
@@ -238,7 +237,7 @@ class EvaluateQueries(ast.NodeVisitor):
             return new_info
         else:
             raise TractQuerierSyntaxError(
-                "Syntax error in query line %d" % node.lineno)
+                f"Syntax error in query line {node.lineno}")
 
     def visit_Str(self, node):
         query_info = FiberQueryInfo()
@@ -304,7 +303,7 @@ class EvaluateQueries(ast.NodeVisitor):
             elif node.func.id.lower() in self.relative_terms:
                 return self.process_relative_term(node)
 
-        raise TractQuerierSyntaxError("Invalid query in line %d" % node.lineno)
+        raise TractQuerierSyntaxError(f"Invalid query in line {node.lineno}")
 
     def process_relative_term(self, node):
         r"""
@@ -349,7 +348,7 @@ class EvaluateQueries(ast.NodeVisitor):
         else:
             raise TractQuerierSyntaxError(
                 "Attribute not recognized for relative specification."
-                "Line %d" % node.lineno
+                f"Line {node.lineno}"
             )
 
         labels = query_info.labels
@@ -368,7 +367,7 @@ class EvaluateQueries(ast.NodeVisitor):
                 )
         except KeyError as e:
             raise TractQuerierLabelNotFound(
-                "Label %s not found in atlas file" % e
+                f"Label {e} not found in atlas file"
             )
         function_name = node.func.id.lower()
 
@@ -436,7 +435,7 @@ class EvaluateQueries(ast.NodeVisitor):
     def visit_Assign(self, node):
         if len(node.targets) > 1:
             raise TractQuerierSyntaxError(
-                "Invalid assignment in line %d" % node.lineno)
+                f"Invalid assignment in line {node.lineno}")
 
         queries_to_evaluate = self.process_assignment(node)
 
@@ -447,7 +446,7 @@ class EvaluateQueries(ast.NodeVisitor):
     def visit_AugAssign(self, node):
         if not isinstance(node.op, ast.BitOr):
             raise TractQuerierSyntaxError(
-                "Invalid assignment in line %d" % node.lineno)
+                f"Invalid assignment in line {node.lineno}")
 
         queries_to_evaluate = self.process_assignment(node)
 
@@ -496,7 +495,7 @@ class EvaluateQueries(ast.NodeVisitor):
                 + target.attr.lower()] = node.value
         else:
             raise TractQuerierSyntaxError(
-                "Invalid assignment in line %d" % node.lineno)
+                f"Invalid assignment in line {node.lineno}")
         return queries_to_evaluate
 
     def rewrite_side_query(self, node):
@@ -542,7 +541,7 @@ class EvaluateQueries(ast.NodeVisitor):
             return self.evaluated_queries_info[node.id]
         else:
             raise TractQuerierSyntaxError(
-                "Invalid query name in line %d: %s" % (node.lineno, node.id))
+                f"Invalid query name in line {node.lineno}: {node.id}")
 
     def visit_Attribute(self, node):
         if not isinstance(node.value, ast.Name):
@@ -554,9 +553,7 @@ class EvaluateQueries(ast.NodeVisitor):
             return self.evaluated_queries_info[query_name]
         else:
             raise TractQuerierSyntaxError(
-                "Invalid query name in line %d: %s" %
-                (node.lineno, query_name)
-            )
+                f"Invalid query name in line {node.lineno}: {query_name}")
 
     def visit_Num(self, node):
         if (
@@ -590,18 +587,16 @@ class EvaluateQueries(ast.NodeVisitor):
                 self.queries_to_save.add(node.value.id)
             else:
                 raise TractQuerierSyntaxError(
-                    "Query %s not known line: %d" %
-                    (node.value.id, node.lineno)
-                )
+                    f"Query {node.value.id} not known line: {node.lineno}")
         elif isinstance(node.value, ast.Module):
             self.visit(node.value)
         else:
             raise TractQuerierSyntaxError(
-                "Invalid expression at line: %d" % (node.lineno))
+                f"Invalid expression at line: {node.lineno}")
 
     def generic_visit(self, node):
         raise TractQuerierSyntaxError(
-            "Invalid Operation %s line: %d" % (type(node), node.lineno))
+            f"Invalid Operation {type(node)} line: {node.lineno}")
 
     def visit_For(self, node):
         id_to_replace = node.target.id.lower()
@@ -617,10 +612,8 @@ class EvaluateQueries(ast.NodeVisitor):
                     list_items.append(item.id.lower())
                 else:
                     raise TractQuerierSyntaxError(
-                        'Error in FOR statement in line %d,'
-                        ' elements in the list must be query names' %
-                        node.lineno
-                    )
+                        f'Error in FOR statement in line {node.lineno},'
+                        ' elements in the list must be query names')
 
         original_body = ast.Module(body=node.body)
 
@@ -755,7 +748,7 @@ class RewritePreprocess(ast.NodeTransformer):
                         break
                 if not found:
                     raise TractQuerierSyntaxError(
-                        'Imported file not found: %s' % file_name
+                        f'Imported file not found: {file_name}'
                     )
             imported_modules = [
                 ast.parse(open(module_name).read(), filename=module_name)
@@ -767,14 +760,7 @@ class RewritePreprocess(ast.NodeTransformer):
             exc_type, exc_value, exc_traceback = sys.exc_info()
             formatted_lines = traceback.format_exc().splitlines()
             raise TractQuerierSyntaxError(
-                'syntax error in line %s line %d: \n%s\n%s' %
-                (
-                    module_name,
-                    exc_value[1][1],
-                    formatted_lines[-3],
-                    formatted_lines[-2]
-                )
-            )
+                f'syntax error in module {module_name} line {exc_value[1][1]}: \n{formatted_lines[-3]}\n{formatted_lines[-2]}')
 
         new_node = ast.Module(imported_modules)
 
@@ -795,16 +781,9 @@ def queries_preprocess(query_file, filename='<unknown>', include_folders=[]):
         exc_type, exc_value, exc_traceback = sys.exc_info()
         formatted_lines = traceback.format_exc().splitlines()
         raise TractQuerierSyntaxError(
-            'syntax error in line %s line %d: \n%s' %
-            (
-                filename,
-                exc_value.lineno,
-                # The offset should not be necessary
-                # If you really need that, use
-                # exc_value.offset
-                exc_value.text
-            )
-        )
+            f'syntax error in line {filename} line {exc_value.lineno}: \n{exc_value.text}')
+            # The offset should not be necessary. If you really need that, use
+            # exc_value.offset
 
     rewrite_preprocess = RewritePreprocess(include_folders=include_folders)
     rewrite_precedence_not_in = RewriteChangeNotInPrescedence()

--- a/tract_querier/tests/datasets.py
+++ b/tract_querier/tests/datasets.py
@@ -55,7 +55,7 @@ class TestDataSet(unittest.TestCase):
             if (
                 hashlib.md5(open(dst_filename).read()).digest() != v[2]
             ):
-                raise IOError('File %s url %s was not properly downloaded' % (v[1], v[0]))
+                raise IOError(f'File {v[1]} url {v[0]} was not properly downloaded')
 
             self.files[k] = dst_filename
 

--- a/tract_querier/tests/test_scripts.py
+++ b/tract_querier/tests/test_scripts.py
@@ -24,7 +24,7 @@ PYTHON = sys.executable
 
 ENVIRON = os.environ.copy()
 sys.path.insert(0, PACKAGE_ROOT_DIR)
-ENVIRON['PYTHONPATH'] = reduce(lambda x, y: '%s:%s' % (x, y), sys.path)
+ENVIRON['PYTHONPATH'] = reduce(lambda x, y: f'{x}:{y}', sys.path)
 
 TEST_DATA = datasets.TestDataSet()
 
@@ -62,11 +62,11 @@ def test_tract_math_count():
     assert popen.returncode == 0
 
 def test_tract_querier_query():
-    output_prefix = '%s/test' % TEST_DATA.dirname
+    output_prefix = f'{TEST_DATA.dirname}/test'
     popen = subprocess.Popen(
         [PYTHON, TRACT_QUERIER_SCRIPT] +
-        ('-a %(atlas_file)s -t %(tract_file)s -q %(query_uf_file)s' % TEST_DATA.files).split() +
-        (' -o %s' % output_prefix).split(),
+        f"-a {TEST_DATA.files['atlas_file']} -t {TEST_DATA.files['tract_file']} -q {TEST_DATA.files['query_uf_file']}".split() +
+        f' -o {output_prefix}'.split(),
         shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         env=ENVIRON
     )

--- a/tract_querier/tract_label_indices.py
+++ b/tract_querier/tract_label_indices.py
@@ -145,9 +145,9 @@ def compute_tract_bounding_boxes(tracts, affine_transform=None):
         if len(ras_coords) < 2:
             raise ValueError(
                 'Tracts in the tractography must have at least 2 points'
-                ' tract #%d has less than two points.'
+                f' tract #{i} has less than two points.'
                 ' You can use the tract_math tool to prune short tracts'
-                ' and solve this problem.' % i
+                ' and solve this problem.'
             )
         bounding_boxes[i] = BoundingBox(ras_coords)
 

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -165,7 +165,7 @@ def process_output(output, file_output=None):
         return
 
     if file_output is not None and path.exists(file_output):
-        in_key = input("Overwrite file %s (y/N)? " % file_output)
+        in_key = input(f"Overwrite file {file_output} (y/N)? ")
         if in_key.lower().strip() != 'y':
             return
 

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -118,13 +118,13 @@ def scalar_tract_mean_std(optional_flags, tractography, scalar):
         tracts = tractography.original_tracts_data()[scalar]
         result = OrderedDict((
             ('tract file', []),
-            ('mean %s' % scalar, []),
-            ('std %s' % scalar, [])
+            (f'mean {scalar}', []),
+            (f'std {scalar}', [])
         ))
         for i, t in enumerate(tracts):
-            result['tract file'].append('Tract %04d' % i)
-            result['mean %s' % scalar].append(t.mean())
-            result['std %s' % scalar].append(t.std())
+            result['tract file'].append(f'Tract {i:04d}')
+            result[f'mean {scalar}'].append(t.mean())
+            result[f'std {scalar}'].append(t.std())
 
         return result
 
@@ -138,11 +138,11 @@ def scalar_tract_median(optional_flags, tractography, scalar):
         tracts = tractography.original_tracts_data()[scalar]
         result = OrderedDict((
             ('tract file', []),
-            ('median %s' % scalar, []),
+            (f'median {scalar}', []),
         ))
         for i, t in enumerate(tracts):
-            result['tract file'].append('Tract %04d' % i)
-            result['median %s' % scalar].append(float(numpy.median(t)))
+            result['tract file'].append(f'Tract {i:04d}')
+            result[f'median {scalar}'].append(float(numpy.median(t)))
 
         return result
     except KeyError:
@@ -157,8 +157,8 @@ def scalar_mean_std(optional_flags, tractography, scalar):
         mean = all_scalars.mean(0)
         std = all_scalars.std(0)
         return OrderedDict((
-            ('mean %s' % scalar, float(mean)),
-            ('std %s' % scalar, float(std))
+            (f'mean {scalar}', float(mean)),
+            (f'std {scalar}', float(std))
         ))
 
     except KeyError:
@@ -173,7 +173,7 @@ def scalar_median(optional_flags, tractography, scalar):
         median = numpy.median(all_scalars)
 
         return OrderedDict((
-            ('median %s' % scalar, float(median)),
+            (f'median {scalar}', float(median)),
         ))
 
     except KeyError:
@@ -759,7 +759,7 @@ def tract_bhattacharyya_coefficient(optional_flags, tractography, resolution, *o
     result = OrderedDict(
         [('tract file', [])]
         + [
-            ('bhattacharyya %s value' % coord[i], [])
+            (f'bhattacharyya {coord[i]} value', [])
             for i in range(3)
         ]
     )
@@ -805,7 +805,7 @@ def tract_bhattacharyya_coefficient(optional_flags, tractography, resolution, *o
         ]
         for i in range(3):
             result['tract file'].append(tract)
-            result['bhattacharyya %s value' % coord[i]].append(
+            result[f'bhattacharyya {coord[i]} value'].append(
                 numpy.nan_to_num(distances[i]))
 
     return result

--- a/tract_querier/tract_math/tensor_operations.py
+++ b/tract_querier/tract_math/tensor_operations.py
@@ -55,8 +55,8 @@ def compute_all_measures(tractography, desired_keys_list, scalars=None, resoluti
         mean_keys_list = list()
         std_keys_list = list()
         for scalar in scalars:
-            mean_key = 'per tract distance weighted mean %s' % scalar
-            std_key = 'per tract distance weighted std %s' % scalar
+            mean_key = f'per tract distance weighted mean {scalar}'
+            std_key = f'per tract distance weighted std {scalar}'
             mean_keys_list.append(mean_key)
             std_keys_list.append(std_key)
             scalars = tractography.tracts_data()[scalar]

--- a/tract_querier/tractography/tests/test_tractography.py
+++ b/tract_querier/tractography/tests/test_tractography.py
@@ -76,7 +76,7 @@ def setup_module(*args, **kwargs):
     dimensions = [(rng.integers(5, max_tract_length), 3) for _ in range(n_tracts)]
     tracts = [rng.standard_normal(d) for d in dimensions]
     tracts_data = {
-        'a%d' % i: [
+        f'a{i}': [
             rng.standard_normal((d[0], k))
             for d in dimensions
         ]

--- a/tract_querier/tractography/tractography.py
+++ b/tract_querier/tractography/tractography.py
@@ -93,8 +93,8 @@ class Tractography:
                             continue
                         if len(v) != len(tracts):
                             raise ValueError(
-                                'Number of elements in attribute %s must '
-                                'be the same as the number of tracts' % k
+                                f'Number of elements in attribute {k} must '
+                                'be the same as the number of tracts'
                             )
                         _, M = v[0].shape
                         for i, tract_v in enumerate(v):
@@ -104,9 +104,7 @@ class Tractography:
                                 (tract_M != M)
                             ):
                                 raise ValueError(
-                                    "Data for tract %s: %d is inconsistent" % (
-                                        k, i)
-                                )
+                                    f"Data for tract {k}: {i} is inconsistent")
         if appending:
             if tracts_data.keys() != self._tracts_data.keys():
                 raise ValueError("Tract data to append not compatible")

--- a/tract_querier/tractography/vtkInterface.py
+++ b/tract_querier/tractography/vtkInterface.py
@@ -297,7 +297,7 @@ def tracts_to_vtkPolyData(tracts, tracts_data={}, lines_indices=None):
             value_ = value
         else:
             raise ValueError(
-                "Data in %s does not have the correct number of items")
+                f"Data in {key} does not have the correct number of items")
 
         vtk_value = ns.numpy_to_vtk(
             np.ascontiguousarray(value_, dtype=ns.get_vtk_to_numpy_typemap()[vtk.VTK_FLOAT]),
@@ -353,13 +353,8 @@ def writeLinesToVtkPolyData_pure_python(filename, lines, point_data={}):
     points_for_line_saved = 0
     for line in lines:
         file_.write(
-            "%d %s \n" % (
-                len(line),
-                reduce(
-                    lambda x, y: x + ' %d' % (y + points_for_line_saved),
-                    range(len(line)), ''
-                )
-            ))
+            f"{len(line)} {reduce(lambda x, y: x + f' {(y + points_for_line_saved)}', range(len(line)), '')} \n"
+        )
         points_for_line_saved += len(line)
 
     if point_data:
@@ -400,8 +395,7 @@ def write_active_components(file_, point_data):
                 (fixed_number_of_components != number_of_components)
             ):
                 raise ValueError(
-                    "Active %s don't have %d components, it has %d" % (
-                        type_, fixed_number_of_components, number_of_components)
+                    f"Active {type_} don't have {fixed_number_of_components} components, it has {number_of_components}"
                 )
             if type_ == 'Scalars':
                 file_.write(__point_data_attribute_header__(
@@ -435,7 +429,7 @@ def write_field_data(file_, number_of_points, active_keys, point_data):
 
         if sum(len(d) for d in data) != number_of_points:
             raise ValueError(
-                "Attribute %s does not have a tuple per point in the line" % key)
+                f"Attribute {key} does not have a tuple per point in the line")
 
         file_.write(
             __field_data_attribute_header__(
@@ -489,30 +483,27 @@ __polyDataType__ = "DATASET POLYDATA\n"
 
 
 def __points_header__(number_of_points):
-    return "POINTS %d float\n" % number_of_points
+    return f"POINTS {number_of_points} float\n"
 
 
 def __lines_header__(number_of_lines, number_of_points):
-    return "LINES %d %d\n" % (number_of_lines, number_of_lines + number_of_points)
+    return f"LINES {number_of_lines} {number_of_lines + number_of_points}\n"
 
 
 def __point_data_header__(number_of_points):
-    return "POINT_DATA %d\n" % number_of_points
+    return f"POINT_DATA {number_of_points}\n"
 
 
 def __point_data_attribute_header__(type_, name, number_of_components=0):
-    return "%s %s float %.d\n" % (type_, name, number_of_components)
+    return f"{type_} {name} float {number_of_components:d}\n"
 
 
 def __field_data_header__(number_of_arrays):
-    return "FIELD FieldData %d\n" % number_of_arrays
+    return f"FIELD FieldData {number_of_arrays}\n"
 
 
 def __field_data_attribute_header__(
     array_name='', number_of_components=1,
     number_of_points=1, data_type='float'
 ):
-    return " % s %d %d %s\n" % (
-        array_name, number_of_components,
-        number_of_points, data_type
-    )
+    return f" {array_name} {number_of_components} {number_of_points} {data_type}\n"


### PR DESCRIPTION
Prefer using f-strings.

Used the `flynt` package to convert as many instances as possible, then did a manual pass.

Take advantage of the commit to fix some messages and missing substitutions:
```
'syntax error in line %s line %d: \n%s\n%s' %
(
    module_name,
    exc_value[1][1],
    formatted_lines[-3],
    formatted_lines[-2]
)
```

and
```
raise ValueError(
    "Data in %s does not have the correct number of items")
```

Documentation:
https://peps.python.org/pep-0498/
https://pypi.org/project/flynt/