### PR TITLE
ENH: Remove Python 2.x legacy conditional import statement

### DIFF
--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -16,11 +16,7 @@ import traceback
 from . import tensor_operations
 from . import tract_operations
 
-
-try:
-    from collections import OrderedDict
-except ImportError:  # Python 2.6 fix
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 
 @tract_math_operation(': print the names of scalar data associated with each tract')

--- a/tract_querier/tract_math/tensor_operations.py
+++ b/tract_querier/tract_math/tensor_operations.py
@@ -3,11 +3,7 @@ from ..tractography import Tractography
 from . import tract_operations
 from ..tensor import scalar_measures
 
-try:
-    from collections import OrderedDict
-except ImportError:  # Python 2.6 fix
-    from ordereddict import OrderedDict
-
+from collections import OrderedDict
 
 
 def compute_all_measures(tractography, desired_keys_list, scalars=None, resolution=None):


### PR DESCRIPTION
Remove Python 2.x legacy conditional import statement: import `OrderedDict` from `collections`.

Support for Python 2.x was dropped following the discussion in https://github.com/demianw/tract_querier/pull/5.