### PR TITLE
DOC: Update installation instructions

### DIFF
--- a/doc/installation_instructions.rst
+++ b/doc/installation_instructions.rst
@@ -6,12 +6,12 @@ Installation Instructions
 
 Requirements
 ------------
-* `Python 2.x, 2.7 or superior <http://www.python.org>`_
-* `NumPy 1.6 or superior <http://www.numpy.org>`_
-* `nibabel 1.3.x <http://nipy.sourceforge.net/nibabel/>`_
-* If you want to be able to use VTK files to represent tractographies (like for interacting with slicer): `VTK 5.x installed along with its python wrappings <http://www.vtk.org>`_
+* `Python >= 3.9, <3.12 <http://www.python.org>`_
+* `NumPy >= 1.23, <2.0.0 <http://www.numpy.org>`_
+* `nibabel >= 3.0.0, <4.0.0 <http://nipy.sourceforge.net/nibabel/>`_
+* If you want to be able to use VTK files to represent tractographies (like for interacting with slicer): `VTK 8.2 installed along with its python wrappings <http://www.vtk.org>`_
 
-All of these can be easily obtained from pre-packaged distributions such as `Canopy <https://www.enthought.com/products/canopy>`_ or `Anaconda <http://docs.continuum.io/anaconda/index.html>`_. In these cases, the packages corresponding to *VTK* and *nibabel* will need to be added.
+All of these can be easily obtained from pre-packaged distributions such as `Anaconda <http://docs.continuum.io/anaconda/index.html>`_. In these cases, the packages corresponding to *VTK* and *nibabel* will need to be added.
 
 Installation
 ------------
@@ -25,7 +25,7 @@ Downloading the source code from git::
 Installing::
 
   cd tract_querier
-  python setup.py install
+  pip install .
 
 
 Now you can check if the installation worked::


### PR DESCRIPTION
Update installation instructions:
- Update the dependencies versions.
- `Canopy` is no longer maintained/available, so remove it.
- Update the instal command to use `pip` as the build system has been changed and there is no `setup.py` file.