### PR TITLE
STYLE: Prefer absolute imports

### DIFF
--- a/tract_querier/__init__.py
+++ b/tract_querier/__init__.py
@@ -1,10 +1,10 @@
 import os
 import sysconfig
 
-from .query_processor import *
-from .tract_label_indices import *
-from .shell import *
-from . import tractography
+from tract_querier.query_processor import *
+from tract_querier.tract_label_indices import *
+from tract_querier.shell import *
+from tract_querier import tractography
 
 
 def find_queries_path():

--- a/tract_querier/nipype/wmql.py
+++ b/tract_querier/nipype/wmql.py
@@ -28,7 +28,7 @@ class TractQuerier(CommandLine):
     Examples
     --------
 
-    >>> from ..nipype.wmql import TractQuerier
+    >>> from tract_querier.nipype.wmql import TractQuerier
     >>> import os
     >>> tract_querier = TractQuerier()
     >>> tract_querier.inputs.atlas_type = 'Desikan'
@@ -85,7 +85,7 @@ class MapImageToTracts(CommandLine):
     Examples
     --------
 
-    >>> from ..nipype.wmql import MapImageToTracts
+    >>> from tract_querier.nipype.wmql import MapImageToTracts
     >>> tract_mapper = MapImageToTracts()
     >>> tract_mapper.inputs.output_tractography_prefix = 'out_'
     >>> tract_mapper.inputs.input_image = 'fa.nii.gz'

--- a/tract_querier/query_processor.py
+++ b/tract_querier/query_processor.py
@@ -5,7 +5,7 @@ from operator import lt, gt
 from itertools import takewhile
 import fnmatch
 
-from .code_util import DocStringInheritor
+from tract_querier.code_util import DocStringInheritor
 
 
 __all__ = [

--- a/tract_querier/shell.py
+++ b/tract_querier/shell.py
@@ -1,7 +1,7 @@
 import ast
 import cmd
 import fnmatch
-from .query_processor import (
+from tract_querier.query_processor import (
     EvaluateQueries, queries_preprocess,
     TractQuerierSyntaxError, TractQuerierLabelNotFound,
     keywords

--- a/tract_querier/tensor/__init__.py
+++ b/tract_querier/tensor/__init__.py
@@ -4,4 +4,4 @@ Utils to handle tensor operations
 
 __all__ = ['scalar_measures']
 
-from . import scalar_measures
+from tract_querier.tensor import scalar_measures

--- a/tract_querier/tensor/tests/test_scalar_measures.py
+++ b/tract_querier/tensor/tests/test_scalar_measures.py
@@ -1,4 +1,4 @@
-from .. import scalar_measures
+from tract_querier.tensor import scalar_measures
 
 import numpy
 from numpy.testing import assert_array_almost_equal

--- a/tract_querier/tests/__init__.py
+++ b/tract_querier/tests/__init__.py
@@ -1,2 +1,2 @@
-from . import test_query_eval
-from . import test_query_files
+from tract_querier.tests import test_query_eval
+from tract_querier.tests import test_query_files

--- a/tract_querier/tests/test_query_eval.py
+++ b/tract_querier/tests/test_query_eval.py
@@ -1,4 +1,4 @@
-from .. import query_processor
+from tract_querier import query_processor
 
 import ast
 import numpy as np

--- a/tract_querier/tests/test_query_files.py
+++ b/tract_querier/tests/test_query_files.py
@@ -1,4 +1,4 @@
-from .. import queries_preprocess, queries_syntax_check
+from tract_querier.query_processor import queries_preprocess, queries_syntax_check
 
 import os
 import fnmatch

--- a/tract_querier/tests/test_query_rewrite.py
+++ b/tract_querier/tests/test_query_rewrite.py
@@ -1,4 +1,4 @@
-from .. import query_processor
+from tract_querier import query_processor
 
 import pytest
 

--- a/tract_querier/tract_label_indices.py
+++ b/tract_querier/tract_label_indices.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-from .aabb import BoundingBox
+from tract_querier.aabb import BoundingBox
 
 __all__ = ['TractographySpatialIndexing']
 

--- a/tract_querier/tract_math/__init__.py
+++ b/tract_querier/tract_math/__init__.py
@@ -1,8 +1,8 @@
 from inspect import getmembers
 
-from .decorator import tract_math_operation, TractMathWrongArgumentsError
+from tract_querier.tract_math.decorator import tract_math_operation, TractMathWrongArgumentsError
 
-from . import operations as _operations
+from tract_querier.tract_math import operations as _operations
 
 operations = dict((
     (f[0], f[1]) for f in getmembers(_operations) if hasattr(f[1], 'help_text')

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -7,7 +7,7 @@ from os import path
 
 import nibabel
 
-from ..tractography import (
+from tract_querier.tractography import (
     Tractography, tractography_to_file
 )
 import os

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -1,4 +1,4 @@
-from .decorator import tract_math_operation, set_dictionary_from_use_filenames_as_index
+from tract_querier.tract_math.decorator import tract_math_operation, set_dictionary_from_use_filenames_as_index
 
 from warnings import warn
 
@@ -7,14 +7,14 @@ import numpy
 import nibabel
 from nibabel.spatialimages import SpatialImage
 
-from ..tractography import (
+from tract_querier.tractography import (
     Tractography, tractography_to_file, tractography_from_files
 )
 
 import sys
 import traceback
-from . import tensor_operations
-from . import tract_operations
+from tract_querier.tract_math import tensor_operations
+from tract_querier.tract_math import tract_operations
 
 
 try:
@@ -697,7 +697,7 @@ def tract_smooth(optional_flags, tractography, var, file_output):
 
 @tract_math_operation('<tract_out>: compute the protoype tract')
 def tract_prototype_median(optional_flags, tractography, file_output=None):
-    from .tract_obb import prototype_tract
+    from tract_querier.tract_math.tract_obb import prototype_tract
 
     tracts = tractography.tracts()
     data = tractography.tracts_data()
@@ -717,7 +717,7 @@ def tract_prototype_median(optional_flags, tractography, file_output=None):
 
 @tract_math_operation('<smooth order> <tract_out>: compute the protoype tract')
 def tract_prototype_mean(optional_flags, tractography, smooth_order, file_output=None):
-    from .tract_obb import prototype_tract
+    from tract_querier.tract_math.tract_obb  import prototype_tract
 
     tracts = tractography.tracts()
     prototype_ix, leave_centers = prototype_tract(

--- a/tract_querier/tract_math/tensor_operations.py
+++ b/tract_querier/tract_math/tensor_operations.py
@@ -1,7 +1,7 @@
 import numpy
-from ..tractography import Tractography
-from . import tract_operations
-from ..tensor import scalar_measures
+from tract_querier.tractography import Tractography
+from tract_querier.tract_math import tract_operations
+from tract_querier.tensor import scalar_measures
 
 try:
     from collections import OrderedDict

--- a/tract_querier/tractography/__init__.py
+++ b/tract_querier/tractography/__init__.py
@@ -1,5 +1,5 @@
-from .tractography import Tractography
-from .trackvis import tractography_from_trackvis_file, tractography_to_trackvis_file
+from tract_querier.tractography.tractography import Tractography
+from tract_querier.tractography.trackvis import tractography_from_trackvis_file, tractography_to_trackvis_file
 
 from warnings import warn
 import numpy
@@ -16,7 +16,7 @@ try:
         'tractography_from_vtk_files', 'tractography_to_vtk_file',
         'vtkPolyData_to_tracts', 'tracts_to_vtkPolyData'
     ]
-    from .vtkInterface import (
+    from tract_querier.tractography.vtkInterface import (
         tractography_from_vtk_files, tractography_to_vtk_file,
         vtkPolyData_to_tracts, tracts_to_vtkPolyData
     )

--- a/tract_querier/tractography/tests/__init__.py
+++ b/tract_querier/tractography/tests/__init__.py
@@ -1,1 +1,1 @@
-from .test_tractography import *
+from tract_querier.tractography.tests.test_tractography import *

--- a/tract_querier/tractography/tests/test_tractography.py
+++ b/tract_querier/tractography/tests/test_tractography.py
@@ -1,12 +1,11 @@
-from .. import Tractography
-from .. import (
+from tract_querier.tractography import Tractography, tractography_from_files, tractography_to_file
+from tract_querier.tractography.trackvis import (
     tractography_from_trackvis_file, tractography_to_trackvis_file,
-    tractography_from_files, tractography_to_file
 )
 
 try:
     VTK = True
-    from ..vtkInterface import (
+    from tract_querier.tractography.vtkInterface import (
         tractography_from_vtk_files, tractography_to_vtk_file,
     )
 except ImportError:

--- a/tract_querier/tractography/trackvis.py
+++ b/tract_querier/tractography/trackvis.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy
 
-from .tractography import Tractography
+from tract_querier.tractography import Tractography
 
 from nibabel import trackvis
 

--- a/tract_querier/tractography/vtkInterface.py
+++ b/tract_querier/tractography/vtkInterface.py
@@ -3,7 +3,7 @@ import vtk
 from vtk.util import numpy_support as ns
 import numpy as np
 
-from .tractography import Tractography
+from tract_querier.tractography import Tractography
 from functools import reduce
 
 


### PR DESCRIPTION
Prefer absoulute import statements: Python PEP 8 recomends using absolute imports:
https://peps.python.org/pep-0008/#imports

"Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) (...)."