### PR TITLE
STYLE: Use a dedicated function to parse script input arguments

### DIFF
--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -10,6 +10,8 @@ import warnings
 import os, sys
 # sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from tract_querier.tract_math import operations
+
 
 def tract_math_operation(help_text, needs_one_tract=True):
     '''
@@ -29,10 +31,7 @@ def tract_math_operation(help_text, needs_one_tract=True):
     return internal_decorator
 
 
-def main():
-    from tract_querier.tract_math import operations
-    from tract_querier.tract_math import TractMathWrongArgumentsError
-
+def _build_arg_parser():
     usage = r"""
     usage: %(prog)s <tract1.vtk> ... <tractN.vtk> operation <operation parameter1> ... <operation parameterN> <output_tract.vtk> \
                       [ optional flags ]
@@ -84,7 +83,15 @@ def main():
     parser.add_argument('operation_parameters', type=str, nargs=REMAINDER,
                         help="operation parameters")
 
+    return parser
+
+
+def main():
+    from tract_querier.tract_math import TractMathWrongArgumentsError
+
+    parser = _build_arg_parser()
     args = parser.parse_args()
+
     # Load the global modules after the parsing of parameters
     from tract_querier.tractography import tractography_from_files
 

--- a/scripts/tract_querier
+++ b/scripts/tract_querier
@@ -64,7 +64,8 @@ def affine_transform_tract(affine_transform, tract):
     return tract
 
 
-def main():
+def _build_arg_parser():
+
     parser = OptionParser(
         version=0.1,
         usage="usage: %prog -t tractography_file -a atlas_file "
@@ -101,6 +102,11 @@ def main():
         "to put both in AC-PC coordinate space"
     )
 
+    return parser
+
+
+def main():
+    parser = _build_arg_parser()
     (options, args) = parser.parse_args()
 
     if (


### PR DESCRIPTION
Use a dedicated function to parse script input arguments: improves readaibility, and reduces the complexity of the `main` method.