### PR TITLE
STYLE: Miscellaneous import cleanup in `tract_math` script

### DIFF
--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -5,11 +5,6 @@ from argparse import ArgumentParser, FileType, REMAINDER
 
 import traceback
 
-import warnings
-
-import os, sys
-# sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-
 from tract_querier.tract_math import operations
 
 


### PR DESCRIPTION
Miscellaneous import cleanup in `tract_math` script:
- Remove unused imports: do not import `os` and `warning`.
- Remove duplicate imports: remove duplicate `sys` import statement.

Take advantage of the commit to remove the commented statement appending the parent directory to the path.