### PR TITLE
ENH: Fix `NiBabel` deprecation warnings

### DIFF
--- a/scripts/tract_querier
+++ b/scripts/tract_querier
@@ -135,7 +135,7 @@ def main():
     #     parser.error(e.value)
 
     labels_nii = nibabel.load(options.atlas_file_name)
-    img = labels_nii.get_data()
+    img = labels_nii.get_fdata()
 
     tr = tract_querier.tractography.tractography_from_file(
         options.tractography_file_name
@@ -163,14 +163,14 @@ def main():
             }
         else:
             tractography_extra_kwargs = {
-                'affine': labels_nii.get_affine(),
+                'affine': labels_nii.affine,
                 'image_dimensions': img.shape
             }
     else:
         tractography_extra_kwargs = {}
 
     print("Calculating labels and crossings")
-    affine_ijk_2_ras = labels_nii.get_affine()
+    affine_ijk_2_ras = labels_nii.affine
     tracts = tr.tracts()
 
     if bounding_box_affine_transform is not None:

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -278,7 +278,7 @@ def tract_map_image(optional_flags, tractography, image, quantity_name, file_out
     image = nibabel.load(image)
 
     ijk_points = tract_operations.tract_in_ijk(image, tractography)
-    image_data = image.get_data()
+    image_data = image.get_fdata()
 
     if image_data.ndim > 3:
         output_name, ext = path.splitext(file_output)
@@ -320,9 +320,9 @@ def tract_deform(optional_flags, tractography, image, file_output=None):
     import numpy as numpy
 
     image = nibabel.load(image)
-    coord_adjustment = numpy.sign(numpy.diag(image.get_affine())[:-1])
+    coord_adjustment = numpy.sign(numpy.diag(image.affine)[:-1])
     ijk_points = tract_operations.tract_in_ijk(image, tractography)
-    image_data = image.get_data().squeeze()
+    image_data = image.get_fdata().squeeze()
 
     if image_data.ndim != 4 and image_data.shape[-1] != 3:
         raise ValueError('Image is not a deformation field')
@@ -362,7 +362,7 @@ def tract_affine_transform(optional_flags,
     import nibabel
     import numpy as numpy
     ref_image = nibabel.load(ref_image)
-    ref_affine = ref_image.get_affine()
+    ref_affine = ref_image.affine
     transform = numpy.loadtxt(transform_file)
     invert = bool(invert)
     if invert:
@@ -440,7 +440,7 @@ def tract_generate_mask(optional_flags, tractography, image, file_output):
     image = nibabel.load(image)
     mask = tract_operations.tract_mask(image, tractography)
 
-    return SpatialImage(mask, image.get_affine())
+    return SpatialImage(mask, image.affine)
 
 
 @tract_math_operation('<image> [smoothing] <image_out>: calculates the probabilistic tract image for these tracts', needs_one_tract=False)
@@ -466,7 +466,7 @@ def tract_generate_population_probability_map(optional_flags, tractographies, im
 
     prob_map /= len(tractographies)
 
-    return SpatialImage(prob_map, image.get_affine()),
+    return SpatialImage(prob_map, image.affine),
 
 
 @tract_math_operation('<image> <image_out>: calculates the probabilistic tract image for these tracts', needs_one_tract=False)
@@ -481,7 +481,7 @@ def tract_generate_probability_map(optional_flags, tractographies, image, file_o
         new_prob_map = tract_operations.tract_mask(image, tract[1])
         prob_map = prob_map + new_prob_map - (prob_map * new_prob_map)
 
-    return SpatialImage(prob_map, image.get_affine())
+    return SpatialImage(prob_map, image.affine)
 
 
 @tract_math_operation('<tractography_out>: strips the data from the tracts', needs_one_tract=True)
@@ -565,7 +565,7 @@ def tract_kappa_volume(optional_flags, tractography, volume, threshold, resoluti
     resolution = float(resolution)
 
     volume = nibabel.load(volume)
-    mask = (volume.get_data() > threshold).astype(int)
+    mask = (volume.get_fdata() > threshold).astype(int)
     voxels = tract_operations.tract_mask(mask, tractography)
 
     result = OrderedDict((
@@ -817,7 +817,7 @@ def tract_flip_endpoints_in_label(
 ):
     image = nibabel.load(image)
     tracts_ijk = tract_operations.each_tract_in_ijk(image, tractography)
-    image_data = image.get_data()
+    image_data = image.get_fdata()
     label = int(label)
     print(image_data.sum())
     needs_flip = []

--- a/tract_querier/tract_math/tract_operations.py
+++ b/tract_querier/tract_math/tract_operations.py
@@ -3,7 +3,7 @@ import numpy
 
 def tract_in_ras(image, tract_ijk):
     ijk_points = tract_ijk
-    ras_points = numpy.dot(image.get_affine(), numpy.hstack((
+    ras_points = numpy.dot(image.affine, numpy.hstack((
         ijk_points,
         numpy.ones((len(ijk_points), 1))
     )).T).T[:, :-1]
@@ -12,7 +12,7 @@ def tract_in_ras(image, tract_ijk):
 
 def tract_in_ijk(image, tractography):
     ras_points = numpy.vstack(tractography.tracts())
-    ijk_points = numpy.linalg.solve(image.get_affine(), numpy.hstack((
+    ijk_points = numpy.linalg.solve(image.affine, numpy.hstack((
         ras_points,
         numpy.ones((len(ras_points), 1))
     )).T).T[:, :-1]
@@ -22,7 +22,7 @@ def tract_in_ijk(image, tractography):
 def each_tract_in_ijk(image, tractography):
     ijk_tracts = []
     for tract in tractography.tracts():
-        ijk_tracts.append(numpy.dot(numpy.linalg.inv(image.get_affine()), numpy.hstack((
+        ijk_tracts.append(numpy.dot(numpy.linalg.inv(image.affine), numpy.hstack((
             tract,
             numpy.ones((len(tract), 1))
         )).T).T[:, :-1])
@@ -31,7 +31,7 @@ def each_tract_in_ijk(image, tractography):
 
 def tract_probability_map(image, tractography):
     ijk_tracts = each_tract_in_ijk(image, tractography)
-    image_data = image.get_data()
+    image_data = image.get_fdata()
 
     probability_map = numpy.zeros_like(image_data, dtype=float)
     for ijk_points in ijk_tracts:
@@ -47,7 +47,7 @@ def tract_probability_map(image, tractography):
 
 def tract_mask(image, tractography):
     ijk_points = tract_in_ijk(image, tractography)
-    image_data = image.get_data()
+    image_data = image.get_fdata()
 
     ijk_clipped = ijk_points.clip(
         (0, 0, 0), numpy.array(image_data.shape) - 1


### PR DESCRIPTION
Fix `NiBabel` deprecation warnings:
- Call `get_fdata()` instead of `get_data()`: `get_data()` is deprecated since version 3.0 and raises an error since version 5.0.
- Call `affine` instead of `get_affine()`: `get_affine()` is deprecated since version 2.1 and raises an error since version 4.0.

The required minimum `NiBabel` version is 3.0 as of the current `HEAD`: commit 221b068.

Fixes:
```
tract_querier/scripts/query_tracts.py:138: DeprecationWarning: get_data() is deprecated in favor of get_fdata(), which has a more predictable return type. To obtain get_data() behavior going forward, use numpy.asanyarray(img.dataobj).

* deprecated from version: 3.0
* Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0
  img = labels_nii.get_data()
```

and
```
tract_querier/scripts/query_tracts.py:173: DeprecationWarning: get_affine method is deprecated.
Please use the ``img.affine`` property instead.

* deprecated from version: 2.1
* Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 4.0
  affine_ijk_2_ras = labels_nii.get_affine()
```

raised locally when running the `tract_querier` script.