### PR TITLE
ENH: Specify Python version in CI documentation build

### DIFF
--- a/.github/workflows/doc_build.yaml
+++ b/.github/workflows/doc_build.yaml
@@ -21,6 +21,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade --user pip setuptools coverage


### PR DESCRIPTION
Specify 3.10 as the Python version in CI documentation build.

Fixes:
```
ERROR: Package 'tract-querier' requires a different Python: 3.12.3 not in '<3.12,>=3.9'
Error: Process completed with exit code 1.
```

raised for example in:
https://github.com/demianw/tract_querier/actions/runs/12833173197/job/35787564658?pr=78