### PR TITLE
DOC: Update package versions in installation instructions

### DIFF
--- a/doc/installation_instructions.rst
+++ b/doc/installation_instructions.rst
@@ -6,9 +6,9 @@ Installation Instructions
 
 Requirements
 ------------
-* `Python >= 3.9, <3.12 <http://www.python.org>`_
-* `NumPy >= 1.23, <2.0.0 <http://www.numpy.org>`_
-* `nibabel >= 3.0.0, <4.0.0 <http://nipy.sourceforge.net/nibabel/>`_
+* `Python >= 3.9 <http://www.python.org>`_
+* `NumPy >= 1.26 <http://www.numpy.org>`_
+* `nibabel >= 4.0.0 <http://nipy.sourceforge.net/nibabel/>`_
 * If you want to be able to use VTK files to represent tractographies (like for interacting with slicer): `VTK 8.2 installed along with its python wrappings <http://www.vtk.org>`_
 
 All of these can be easily obtained from pre-packaged distributions such as `Anaconda <http://docs.continuum.io/anaconda/index.html>`_. In these cases, the packages corresponding to *VTK* and *nibabel* will need to be added.


### PR DESCRIPTION
Update package version in installation instructions.

After commits 813b570 and e72d4e3 were merged, the minimum `NiBabel` version was raised to 4.0.0 and the restriction on newer versions was removed, and the minimum `NumPy` version was raised to 1.26 and newer versions were allowed.

This enabled to use Python version greater than 3.12.